### PR TITLE
JPetRawSignal, JPetEvent support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_subdirectory(src)
 add_subdirectory(tests)
 #add_subdirectory(geometry)
 
-add_definitions(-std=c++11 -Wall -Wunused-parameter -Wextra)
+add_definitions(-std=c++11 -Wall -Wunused-parameter -Wextra -pthread)
 
 
 include_directories(${INCLUDE_PARENT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,21 +48,7 @@ link_directories(${LIBRARY_PARENT})
 
 add_executable(EventDisplay.exe ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(EventDisplay.exe eventDisplay JPetFramework ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
-#add_executable(createGeometryPET.exe ${CMAKE_CURRENT_SOURCE_DIR}/geometry/createGeometryPET.cpp)
-#target_link_libraries(createGeometryPET.exe  geometryGenerator ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
 
-#add_custom_command(
-#  OUTPUT JPET_geom.root
-#  COMMAND createGeometryPET.exe
-#  DEPENDS 
-#  COMMENT "Create geometry for visualizator"
-#  VERBATIM
-#)
-#
-#add_custom_target(
-#  CreateGeometry ALL
-#  DEPENDS JPET_geom.root
-#)
 set(DOWNLOAD_DATA ${CMAKE_CURRENT_SOURCE_DIR}/download_data.sh ${CMAKE_CURRENT_BINARY_DIR})
 if(NOT DOWNLOAD_DATA_HAPPENED)
   execute_process(COMMAND ${DOWNLOAD_DATA})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(LIBRARY_PARENT ${ROOT_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} )
 
 add_subdirectory(src)
 add_subdirectory(tests)
-add_subdirectory(geometry)
+#add_subdirectory(geometry)
 
 add_definitions(-std=c++11 -Wall -Wunused-parameter -Wextra)
 
@@ -51,18 +51,18 @@ target_link_libraries(EventDisplay.exe eventDisplay JPetFramework ${Boost_LIBRAR
 add_executable(createGeometryPET.exe ${CMAKE_CURRENT_SOURCE_DIR}/geometry/createGeometryPET.cpp)
 target_link_libraries(createGeometryPET.exe  geometryGenerator ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
 
-add_custom_command(
-  OUTPUT JPET_geom.root
-  COMMAND createGeometryPET.exe
-  DEPENDS 
-  COMMENT "Create geometry for visualizator"
-  VERBATIM
-)
-
-add_custom_target(
-  CreateGeometry ALL
-  DEPENDS JPET_geom.root
-)
+#add_custom_command(
+#  OUTPUT JPET_geom.root
+#  COMMAND createGeometryPET.exe
+#  DEPENDS 
+#  COMMENT "Create geometry for visualizator"
+#  VERBATIM
+#)
+#
+#add_custom_target(
+#  CreateGeometry ALL
+#  DEPENDS JPET_geom.root
+#)
 set(DOWNLOAD_DATA ${CMAKE_CURRENT_SOURCE_DIR}/download_data.sh ${CMAKE_CURRENT_BINARY_DIR})
 if(NOT DOWNLOAD_DATA_HAPPENED)
   execute_process(COMMAND ${DOWNLOAD_DATA})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ link_directories(${LIBRARY_PARENT})
 
 add_executable(EventDisplay.exe ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(EventDisplay.exe eventDisplay JPetFramework ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
-add_executable(createGeometryPET.exe ${CMAKE_CURRENT_SOURCE_DIR}/geometry/createGeometryPET.cpp)
-target_link_libraries(createGeometryPET.exe  geometryGenerator ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
+#add_executable(createGeometryPET.exe ${CMAKE_CURRENT_SOURCE_DIR}/geometry/createGeometryPET.cpp)
+#target_link_libraries(createGeometryPET.exe  geometryGenerator ${Boost_LIBRARIES} ${ROOT_LIBRARIES})
 
 #add_custom_command(
 #  OUTPUT JPET_geom.root

--- a/README
+++ b/README
@@ -13,11 +13,18 @@ The latest stable version can be downloaded from the github repository. You must
 
 git clone --recursive https://github.com/JPETTomography/j-pet-event-display.git
 
-Current status/know bugs
+Current status
 -----------------------
-Currently only 2 type of files works, TimeWindow and RawSignal. 
-There aren't many checks for data integration so user should always load geometry before loading data. 
-Also after loading data, there is some freez while JPetGeomMapping is mapping scintilators/layers. 
+Currently 4 types of objects can be visualized:
+-- JPetTimeWindow
+-- JPetRawSignal
+-- JPetHit
+-- JPetEvent 
+There are 4 types of views:
+-- 3d view(to enable external openGL 3d viewer root should be compiled with --enable-opengl flag)
+-- unrolled view showing actived scintillators and hit position on scintillators
+-- front view 2d view from front of tomograph
+-- diagram view showing time difference between leading and trailing edge on each threshold
 
 Documentation
 -------------
@@ -43,4 +50,4 @@ Bug Reporting & Contact
 -----------------------
 
 If you have any question or comment please write to: 
-wojciech.krzemien@ncbj.gov.pl
+wojciech.krzemien@ncbj.gov.pl or kamil.rakoczy@student.uj.edu.pl

--- a/main.cpp
+++ b/main.cpp
@@ -12,13 +12,17 @@
  *
  */
 
+#include "src/EventDisplay.h"
 #include <TRint.h>
 #include <iostream>
-#include "src/EventDisplay.h"
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   using namespace jpet_event_display;
-  EventDisplay myDisplay;
+  EventDisplay myDisplay("large_barrel.json", 44, 3, 50,
+                         std::vector< std::pair< int, double > >(
+                             {std::pair< int, double >(48, 42.5),
+                              std::pair< int, double >(48, 46.75),
+                              std::pair< int, double >(96, 57.5)}));
   return 0;
 }

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -211,28 +211,22 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
   auto data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
   float startPos = data.begin()->second.second;
   float diff[4];
-  int i = 0;
   for (auto it = data.begin(); it != data.end(); it++)
   {
-    diff[i] = startPos - it->second.second;
-    if (diff[i] > 0)
-      diff[i] = -diff[i];
+    diff[it->first] = it->second.second - startPos;
     r.push_back(std::make_tuple(
         it->first, it->second.first, 0, JPetSigCh::Leading,
         rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getSide(), pos.layer,
         pos.slot));
-    i++;
   }
-  i = 0;
   auto tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
     r.push_back(std::make_tuple(
-        it->first, it->second.first, it->second.second - diff[i] - startPos,
-        JPetSigCh::Trailing,
+        it->first, it->second.first,
+        it->second.second - diff[it->first] - startPos, JPetSigCh::Trailing,
         rawSignal.getPoints(JPetSigCh::Trailing)[0].getPM().getSide(),
         pos.layer, pos.slot));
-    i++;
   }
   return r;
 }

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -56,6 +56,7 @@ void DataProcessor::getDataForCurrentEvent()
     getHitsPosition(getCurrentEvent< JPetEvent >());
     break;
   default:
+    ProcessedData::getInstance().addToInfo("Not implemented object type");
     break;
   }
 }
@@ -349,11 +350,6 @@ bool DataProcessor::openFile(const char *filename)
   bool r = fReader.openFileAndLoadData(filename);
   dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
       "ParamBank")); // just read param bank, no need to save it to variable
-  // JPetParamManager *manager = dynamic_cast< JPetParamManager *
-  // >(fReader.getObjectFromFile(
-  //    "ParamBank")); // just read param bank, no need to save it to variable
-  // fMapper = std::unique_ptr< JPetGeomMapping >(new
-  // JPetGeomMapping(manager->getParamBank()));
   fNumberOfEventsInFile = fReader.getNbOfAllEvents();
   if (r)
   {

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -18,7 +18,7 @@
 namespace jpet_event_display
 {
 
-DataProcessor::DataProcessor(const std::string paramGetterAnsiiPath,
+DataProcessor::DataProcessor(const std::string &paramGetterAnsiiPath,
                              const int runNumber)
 {
   std::cout

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -18,63 +18,83 @@
 namespace jpet_event_display
 {
 
+DataProcessor::DataProcessor()
+{
+  std::cout
+      << "Generating GeomMapping, please wait, application will start soon... "
+      << "\n";
+  JPetParamManager fparamManagerInstance(
+      new JPetParamGetterAscii("large_barrel.json"));
+  fparamManagerInstance.fillParameterBank(43);
+  auto bank = fparamManagerInstance.getParamBank();
+  dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
+      "ParamBank")); // just read param bank, no need to save it to variable
+  fMapper = std::unique_ptr< JPetGeomMapping >(new JPetGeomMapping(bank));
+}
+
 void DataProcessor::getDataForCurrentEvent()
 {
   ProcessedData::getInstance().clearData();
   switch (ProcessedData::getInstance().getCurrentFileType())
   {
-    case FileTypes::fTimeWindow:
-      getActiveScintillators(getCurrentEvent<JPetTimeWindow>());
-      break;
-    case FileTypes::fRawSignal:
-      getActiveScintillators(getCurrentEvent<JPetRawSignal>());
-      getDataForDiagram(getCurrentEvent<JPetRawSignal>());
-      break;
-    case FileTypes::fHit:
-      getActiveScintillators(getCurrentEvent<JPetHit>());
-      getDataForDiagram(getCurrentEvent<JPetHit>());
-      getHitsPosition(getCurrentEvent<JPetHit>());
-      break;
-    case FileTypes::fEvent:
-      getActiveScintillators(getCurrentEvent<JPetEvent>());
-      getDataForDiagram(getCurrentEvent<JPetEvent>());
-      getHitsPosition(getCurrentEvent<JPetEvent>());
-      break;
-    default:
-      break;
+  case FileTypes::fTimeWindow:
+    getActiveScintillators(getCurrentEvent< JPetTimeWindow >());
+    break;
+  case FileTypes::fRawSignal:
+    getActiveScintillators(getCurrentEvent< JPetRawSignal >());
+    getDataForDiagram(getCurrentEvent< JPetRawSignal >());
+    break;
+  case FileTypes::fHit:
+    getActiveScintillators(getCurrentEvent< JPetHit >());
+    getDataForDiagram(getCurrentEvent< JPetHit >());
+    getHitsPosition(getCurrentEvent< JPetHit >());
+    break;
+  case FileTypes::fEvent:
+    getActiveScintillators(getCurrentEvent< JPetEvent >());
+    getDataForDiagram(getCurrentEvent< JPetEvent >());
+    getHitsPosition(getCurrentEvent< JPetEvent >());
+    break;
+  default:
+    break;
   }
 }
 
-template<typename T>
-const T& DataProcessor::getCurrentEvent()
+template < typename T > const T &DataProcessor::getCurrentEvent()
 {
-  return dynamic_cast<T &>(fReader.getCurrentEvent());
+  return dynamic_cast< T & >(fReader.getCurrentEvent());
 }
 
-void DataProcessor::getActiveScintillators(const JPetTimeWindow& tWindow)
+void DataProcessor::getActiveScintillators(const JPetTimeWindow &tWindow)
 {
   auto sigChannels = tWindow.getSigChVect();
   ScintillatorsInLayers selection;
-  for (const auto & channel : sigChannels) {
+  for (const auto &channel : sigChannels)
+  {
     auto PM = channel.getPM();
-    if(PM.isNullObject()) {
+    if (PM.isNullObject())
+    {
       continue;
     }
     auto scin = PM.getScin();
-    if(scin.isNullObject()) {
+    if (scin.isNullObject())
+    {
       continue;
     }
     auto barrel = scin.getBarrelSlot();
-    if (barrel.isNullObject()) {
+    if (barrel.isNullObject())
+    {
       continue;
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end()) {
+    if (selection.find(pos.layer) != selection.end())
+    {
       if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
                     pos.slot) == selection[pos.layer].end())
         selection[pos.layer].push_back(pos.slot);
-    } else {
+    }
+    else
+    {
       selection[pos.layer] = {pos.slot};
     }
   }
@@ -87,50 +107,64 @@ void DataProcessor::getActiveScintillators(const JPetRawSignal &rawSignal)
   auto leadingSigCh = rawSignal.getPoints(JPetSigCh::Leading);
   auto trailingSigCh = rawSignal.getPoints(JPetSigCh::Trailing);
   ScintillatorsInLayers selection;
-  for (const auto &channel : leadingSigCh) {
+  for (const auto &channel : leadingSigCh)
+  {
     auto PM = channel.getPM();
-    if (PM.isNullObject()) {
+    if (PM.isNullObject())
+    {
       continue;
     }
     auto scin = PM.getScin();
-    if (scin.isNullObject()) {
+    if (scin.isNullObject())
+    {
       continue;
     }
     auto barrel = scin.getBarrelSlot();
-    if (barrel.isNullObject()) {
+    if (barrel.isNullObject())
+    {
       continue;
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end()) {
+    if (selection.find(pos.layer) != selection.end())
+    {
       if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
                     pos.slot) == selection[pos.layer].end())
         selection[pos.layer].push_back(pos.slot);
-    } else {
+    }
+    else
+    {
       selection[pos.layer] = {pos.slot};
     }
   }
 
-  for (const auto &channel : trailingSigCh) {
+  for (const auto &channel : trailingSigCh)
+  {
     auto PM = channel.getPM();
-    if (PM.isNullObject()) {
+    if (PM.isNullObject())
+    {
       continue;
     }
     auto scin = PM.getScin();
-    if (scin.isNullObject()) {
+    if (scin.isNullObject())
+    {
       continue;
     }
     auto barrel = scin.getBarrelSlot();
-    if (barrel.isNullObject()) {
+    if (barrel.isNullObject())
+    {
       continue;
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end()) {
+    if (selection.find(pos.layer) != selection.end())
+    {
       if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
                     pos.slot) == selection[pos.layer].end())
         selection[pos.layer].push_back(pos.slot);
-    } else {
+    }
+    else
+    {
       selection[pos.layer] = {pos.slot};
     }
   }
@@ -140,17 +174,6 @@ void DataProcessor::getActiveScintillators(const JPetRawSignal &rawSignal)
 
 void DataProcessor::getActiveScintillators(const JPetHit &hitSignal)
 {
-
-  //std::cout << "x: " << hitSignal.getPosX() << " y: " << hitSignal.getPosY()
-  //          << " z: " << hitSignal.getPosZ()
-  //          << " energy: " << hitSignal.getEnergy()
-  //          << " qualityOfEnergy: " << hitSignal.getQualityOfEnergy()
-  //          << " time: " << hitSignal.getTime()
-  //          << " timeDiff: " << hitSignal.getTimeDiff()
-  //          << " qualityOfTime: " << hitSignal.getQualityOfTime()
-  //          << " qualityOfTimeDiff: " << hitSignal.getQualityOfTimeDiff()
-  //          << "\n";
-
   ScintillatorsInLayers selection;
   StripPos pos = fMapper->getStripPos(hitSignal.getBarrelSlot());
   selection[pos.layer] = {pos.slot};
@@ -161,16 +184,8 @@ void DataProcessor::getActiveScintillators(const JPetHit &hitSignal)
 void DataProcessor::getActiveScintillators(const JPetEvent &event)
 {
   ScintillatorsInLayers selection;
-  for(JPetHit hit : event.getHits())
+  for (JPetHit hit : event.getHits())
   {
-    //std::cout << "x: " << hit.getPosX() << " y: " << hit.getPosY()
-    //          << " z: " << hit.getPosZ() << " energy: " << hit.getEnergy()
-    //          << " qualityOfEnergy: " << hit.getQualityOfEnergy()
-    //          << " time: " << hit.getTime()
-    //          << " timeDiff: " << hit.getTimeDiff()
-    //          << " qualityOfTime: " << hit.getQualityOfTime()
-    //          << " qualityOfTimeDiff: " << hit.getQualityOfTimeDiff() << "\n";
-
     StripPos pos = fMapper->getStripPos(hit.getBarrelSlot());
     if (selection.find(pos.layer) != selection.end())
     {
@@ -187,20 +202,21 @@ void DataProcessor::getActiveScintillators(const JPetEvent &event)
   ProcessedData::getInstance().setActivedScins(selection);
 }
 
-DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal, bool)
+DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
+                                                bool)
 {
   DiagramDataMap r;
   auto data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
   for (auto it = data.begin(); it != data.end(); it++)
   {
-    r.push_back(std::make_tuple(it->first, it->second.first,
-                                it->second.second, JPetSigCh::Leading));
+    r.push_back(std::make_tuple(it->first, it->second.first, it->second.second,
+                                JPetSigCh::Leading));
   }
   auto tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
-    r.push_back(std::make_tuple(it->first, it->second.first,
-                                it->second.second, JPetSigCh::Trailing));
+    r.push_back(std::make_tuple(it->first, it->second.first, it->second.second,
+                                JPetSigCh::Trailing));
   }
   return r;
 }
@@ -225,7 +241,7 @@ void DataProcessor::getDataForDiagram(const JPetHit &hitSignal)
 void DataProcessor::getDataForDiagram(const JPetEvent &event)
 {
   DiagramDataMapVector rv;
-  for(JPetHit hit : event.getHits())
+  for (JPetHit hit : event.getHits())
   {
     rv.push_back(getDataForDiagram(
         hit.getSignalA().getRecoSignal().getRawSignal(), true));
@@ -254,7 +270,7 @@ void DataProcessor::getHitsPosition(const JPetEvent &event)
 
 bool DataProcessor::openFile(const char *filename)
 {
-  static std::map<std::string, int> compareMap;
+  static std::map< std::string, int > compareMap;
   if (compareMap.empty())
   {
     compareMap["JPetTimeWindow"] = FileTypes::fTimeWindow;
@@ -264,43 +280,25 @@ bool DataProcessor::openFile(const char *filename)
   }
   bool r = fReader.openFileAndLoadData(filename);
   fNumberOfEventsInFile = fReader.getNbOfAllEvents();
-  if(r)
+  if (r)
   {
-    TTree *fTree = dynamic_cast<TTree *>(fReader.getObjectFromFile("tree"));
+    TTree *fTree = dynamic_cast< TTree * >(fReader.getObjectFromFile("tree"));
     TObjArray *arr = fTree->GetListOfBranches();
-    TBranch *fBranch = dynamic_cast<TBranch*>(arr->At(0));
+    TBranch *fBranch = dynamic_cast< TBranch * >(arr->At(0));
     const char *branchName = fBranch->GetClassName();
-    ProcessedData::getInstance().setCurrentFileType(static_cast<FileTypes>(compareMap[branchName]));
-    // set mapper
-    JPetParamManager fparamManagerInstance(new JPetParamGetterAscii("large_barrel.json"));
-    fparamManagerInstance.fillParameterBank(43);
-    auto bank = fparamManagerInstance.getParamBank();
-    //const JPetParamBank *bank2 =
-    dynamic_cast<JPetParamBank *>(fReader.getObjectFromFile("ParamBank")); // just read param bank, no need to save it to variable
-    fMapper = std::unique_ptr<JPetGeomMapping>(new JPetGeomMapping(bank));
+    ProcessedData::getInstance().setCurrentFileType(
+        static_cast< FileTypes >(compareMap[branchName]));
   }
   return r;
 }
 
-void DataProcessor::closeFile()
-{
-  fReader.closeFile();
-}
+void DataProcessor::closeFile() { fReader.closeFile(); }
 
-bool DataProcessor::nextEvent()
-{
-  return fReader.nextEvent();
-}
+bool DataProcessor::nextEvent() { return fReader.nextEvent(); }
 
-bool DataProcessor::firstEvent()
-{
-  return fReader.firstEvent();
-}
+bool DataProcessor::firstEvent() { return fReader.firstEvent(); }
 
-bool DataProcessor::lastEvent()
-{
-  return fReader.lastEvent();
-}
+bool DataProcessor::lastEvent() { return fReader.lastEvent(); }
 
 bool DataProcessor::nthEvent(long long n)
 {

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -237,7 +237,7 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
     if (diff[i] > 0)
       diff[i] = -diff[i];
     r.push_back(std::make_tuple(
-        it->first, it->second.first, startPos, JPetSigCh::Leading,
+        it->first, it->second.first, 0, JPetSigCh::Leading,
         rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getSide(), pos.layer,
         pos.slot));
     i++;
@@ -247,7 +247,7 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
     r.push_back(std::make_tuple(
-        it->first, it->second.first, it->second.second - diff[i],
+        it->first, it->second.first, it->second.second - diff[i] - startPos,
         JPetSigCh::Trailing,
         rawSignal.getPoints(JPetSigCh::Trailing)[0].getPM().getSide(),
         pos.layer, pos.slot));

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -196,10 +196,12 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal)
 {
   DiagramDataMap data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
   DiagramDataMap tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
+  int dataSize = data.size();
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
-    data[it->first + data.size()] = it->second;
+    data[it->first + dataSize] = it->second;
   }
+
   return data;
 }
 

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -85,6 +85,21 @@ std::string DataProcessor::currentActivedScintillatorsInfo()
   return oss.str();
 }
 
+void DataProcessor::addToSelectionIfNotPresent(ScintillatorsInLayers &selection,
+                                               StripPos &pos)
+{
+  if (selection.find(pos.layer) != selection.end())
+  {
+    if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
+                  pos.slot) == selection[pos.layer].end())
+      selection[pos.layer].push_back(pos.slot);
+  }
+  else
+  {
+    selection[pos.layer] = {pos.slot};
+  }
+}
+
 void DataProcessor::getActiveScintillators(const JPetTimeWindow &tWindow)
 {
   auto sigChannels = tWindow.getSigChVect();
@@ -108,16 +123,7 @@ void DataProcessor::getActiveScintillators(const JPetTimeWindow &tWindow)
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end())
-    {
-      if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
-                    pos.slot) == selection[pos.layer].end())
-        selection[pos.layer].push_back(pos.slot);
-    }
-    else
-    {
-      selection[pos.layer] = {pos.slot};
-    }
+    addToSelectionIfNotPresent(selection, pos);
   }
 
   ProcessedData::getInstance().setActivedScins(selection);
@@ -147,16 +153,7 @@ void DataProcessor::getActiveScintillators(const JPetRawSignal &rawSignal)
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end())
-    {
-      if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
-                    pos.slot) == selection[pos.layer].end())
-        selection[pos.layer].push_back(pos.slot);
-    }
-    else
-    {
-      selection[pos.layer] = {pos.slot};
-    }
+    addToSelectionIfNotPresent(selection, pos);
   }
 
   for (const auto &channel : trailingSigCh)
@@ -178,16 +175,7 @@ void DataProcessor::getActiveScintillators(const JPetRawSignal &rawSignal)
     }
     StripPos pos = fMapper->getStripPos(barrel);
 
-    if (selection.find(pos.layer) != selection.end())
-    {
-      if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
-                    pos.slot) == selection[pos.layer].end())
-        selection[pos.layer].push_back(pos.slot);
-    }
-    else
-    {
-      selection[pos.layer] = {pos.slot};
-    }
+    addToSelectionIfNotPresent(selection, pos);
   }
 
   ProcessedData::getInstance().setActivedScins(selection);
@@ -208,16 +196,7 @@ void DataProcessor::getActiveScintillators(const JPetEvent &event)
   for (JPetHit hit : event.getHits())
   {
     StripPos pos = fMapper->getStripPos(hit.getBarrelSlot());
-    if (selection.find(pos.layer) != selection.end())
-    {
-      if (std::find(selection[pos.layer].begin(), selection[pos.layer].end(),
-                    pos.slot) == selection[pos.layer].end())
-        selection[pos.layer].push_back(pos.slot);
-    }
-    else
-    {
-      selection[pos.layer] = {pos.slot};
-    }
+    addToSelectionIfNotPresent(selection, pos);
   }
 
   ProcessedData::getInstance().setActivedScins(selection);

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -205,7 +205,7 @@ void DataProcessor::getActiveScintillators(const JPetEvent &event)
 DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
                                                 bool)
 {
-  DiagramDataMap r;
+  DiagramDataMap diagramData;
   StripPos pos = fMapper->getStripPos(
       rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getBarrelSlot());
   auto data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
@@ -214,7 +214,7 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
   for (auto it = data.begin(); it != data.end(); it++)
   {
     diff[it->first] = it->second.second - startPos;
-    r.push_back(std::make_tuple(
+    diagramData.push_back(std::make_tuple(
         it->first, it->second.first, 0, JPetSigCh::Leading,
         rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getSide(), pos.layer,
         pos.slot));
@@ -222,30 +222,30 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
   auto tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
-    r.push_back(std::make_tuple(
+    diagramData.push_back(std::make_tuple(
         it->first, it->second.first,
         it->second.second - diff[it->first] - startPos, JPetSigCh::Trailing,
         rawSignal.getPoints(JPetSigCh::Trailing)[0].getPM().getSide(),
         pos.layer, pos.slot));
   }
-  return r;
+  return diagramData;
 }
 
 void DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal)
 {
-  DiagramDataMapVector rv;
-  rv.push_back(getDataForDiagram(rawSignal, true));
-  ProcessedData::getInstance().setDiagram(rv);
+  DiagramDataMapVector diagramDataVector;
+  diagramDataVector.push_back(getDataForDiagram(rawSignal, true));
+  ProcessedData::getInstance().setDiagram(diagramDataVector);
 }
 
 void DataProcessor::getDataForDiagram(const JPetHit &hitSignal)
 {
-  DiagramDataMapVector rv;
-  rv.push_back(getDataForDiagram(
+  DiagramDataMapVector diagramDataVector;
+  diagramDataVector.push_back(getDataForDiagram(
       hitSignal.getSignalA().getRecoSignal().getRawSignal(), true));
-  rv.push_back(getDataForDiagram(
+  diagramDataVector.push_back(getDataForDiagram(
       hitSignal.getSignalB().getRecoSignal().getRawSignal(), true));
-  ProcessedData::getInstance().setDiagram(rv);
+  ProcessedData::getInstance().setDiagram(diagramDataVector);
 
   StripPos pos = fMapper->getStripPos(hitSignal.getSignalA()
                                           .getRecoSignal()
@@ -263,14 +263,14 @@ void DataProcessor::getDataForDiagram(const JPetHit &hitSignal)
 
 void DataProcessor::getDataForDiagram(const JPetEvent &event)
 {
-  DiagramDataMapVector rv;
+  DiagramDataMapVector diagramDataVector;
   if (event.getHits().size() < 1)
     return;
   for (JPetHit hit : event.getHits())
   {
-    rv.push_back(getDataForDiagram(
+    diagramDataVector.push_back(getDataForDiagram(
         hit.getSignalA().getRecoSignal().getRawSignal(), true));
-    rv.push_back(getDataForDiagram(
+    diagramDataVector.push_back(getDataForDiagram(
         hit.getSignalB().getRecoSignal().getRawSignal(), true));
 
     StripPos pos = fMapper->getStripPos(hit.getSignalA()
@@ -290,7 +290,7 @@ void DataProcessor::getDataForDiagram(const JPetEvent &event)
         << "r: " << r << " theta: " << (fi * 180.0) / M_PI << "\n";
     ProcessedData::getInstance().addToInfo(oss.str());
   }
-  ProcessedData::getInstance().setDiagram(rv);
+  ProcessedData::getInstance().setDiagram(diagramDataVector);
 }
 
 void DataProcessor::getHitsPosition(const JPetHit &hitSignal)

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -141,15 +141,15 @@ void DataProcessor::getActiveScintillators(const JPetRawSignal &rawSignal)
 void DataProcessor::getActiveScintillators(const JPetHit &hitSignal)
 {
 
-  std::cout << "x: " << hitSignal.getPosX() << " y: " << hitSignal.getPosY()
-            << " z: " << hitSignal.getPosZ()
-            << " energy: " << hitSignal.getEnergy()
-            << " qualityOfEnergy: " << hitSignal.getQualityOfEnergy()
-            << " time: " << hitSignal.getTime()
-            << " timeDiff: " << hitSignal.getTimeDiff()
-            << " qualityOfTime: " << hitSignal.getQualityOfTime()
-            << " qualityOfTimeDiff: " << hitSignal.getQualityOfTimeDiff()
-            << "\n";
+  //std::cout << "x: " << hitSignal.getPosX() << " y: " << hitSignal.getPosY()
+  //          << " z: " << hitSignal.getPosZ()
+  //          << " energy: " << hitSignal.getEnergy()
+  //          << " qualityOfEnergy: " << hitSignal.getQualityOfEnergy()
+  //          << " time: " << hitSignal.getTime()
+  //          << " timeDiff: " << hitSignal.getTimeDiff()
+  //          << " qualityOfTime: " << hitSignal.getQualityOfTime()
+  //          << " qualityOfTimeDiff: " << hitSignal.getQualityOfTimeDiff()
+  //          << "\n";
 
   ScintillatorsInLayers selection;
   StripPos pos = fMapper->getStripPos(hitSignal.getBarrelSlot());
@@ -163,13 +163,13 @@ void DataProcessor::getActiveScintillators(const JPetEvent &event)
   ScintillatorsInLayers selection;
   for(JPetHit hit : event.getHits())
   {
-    std::cout << "x: " << hit.getPosX() << " y: " << hit.getPosY()
-              << " z: " << hit.getPosZ() << " energy: " << hit.getEnergy()
-              << " qualityOfEnergy: " << hit.getQualityOfEnergy()
-              << " time: " << hit.getTime()
-              << " timeDiff: " << hit.getTimeDiff()
-              << " qualityOfTime: " << hit.getQualityOfTime()
-              << " qualityOfTimeDiff: " << hit.getQualityOfTimeDiff() << "\n";
+    //std::cout << "x: " << hit.getPosX() << " y: " << hit.getPosY()
+    //          << " z: " << hit.getPosZ() << " energy: " << hit.getEnergy()
+    //          << " qualityOfEnergy: " << hit.getQualityOfEnergy()
+    //          << " time: " << hit.getTime()
+    //          << " timeDiff: " << hit.getTimeDiff()
+    //          << " qualityOfTime: " << hit.getQualityOfTime()
+    //          << " qualityOfTimeDiff: " << hit.getQualityOfTimeDiff() << "\n";
 
     StripPos pos = fMapper->getStripPos(hit.getBarrelSlot());
     if (selection.find(pos.layer) != selection.end())

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -27,8 +27,6 @@ DataProcessor::DataProcessor()
       new JPetParamGetterAscii("large_barrel.json"));
   fparamManagerInstance.fillParameterBank(43);
   auto bank = fparamManagerInstance.getParamBank();
-  dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
-      "ParamBank")); // just read param bank, no need to save it to variable
   fMapper = std::unique_ptr< JPetGeomMapping >(new JPetGeomMapping(bank));
 }
 
@@ -279,6 +277,8 @@ bool DataProcessor::openFile(const char *filename)
     compareMap["JPetEvent"] = FileTypes::fEvent;
   }
   bool r = fReader.openFileAndLoadData(filename);
+  dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
+      "ParamBank")); // just read param bank, no need to save it to variable
   fNumberOfEventsInFile = fReader.getNbOfAllEvents();
   if (r)
   {

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -18,14 +18,15 @@
 namespace jpet_event_display
 {
 
-DataProcessor::DataProcessor()
+DataProcessor::DataProcessor(const std::string paramGetterAnsiiPath,
+                             const int runNumber)
 {
   std::cout
       << "Generating GeomMapping, please wait, application will start soon... "
       << "\n";
   JPetParamManager fparamManagerInstance(
-      new JPetParamGetterAscii("large_barrel.json"));
-  fparamManagerInstance.fillParameterBank(44);
+      new JPetParamGetterAscii(paramGetterAnsiiPath));
+  fparamManagerInstance.fillParameterBank(runNumber);
   auto bank = fparamManagerInstance.getParamBank();
   fMapper = std::unique_ptr< JPetGeomMapping >(new JPetGeomMapping(bank));
 }
@@ -348,6 +349,11 @@ bool DataProcessor::openFile(const char *filename)
   bool r = fReader.openFileAndLoadData(filename);
   dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
       "ParamBank")); // just read param bank, no need to save it to variable
+  // JPetParamManager *manager = dynamic_cast< JPetParamManager *
+  // >(fReader.getObjectFromFile(
+  //    "ParamBank")); // just read param bank, no need to save it to variable
+  // fMapper = std::unique_ptr< JPetGeomMapping >(new
+  // JPetGeomMapping(manager->getParamBank()));
   fNumberOfEventsInFile = fReader.getNbOfAllEvents();
   if (r)
   {

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -279,6 +279,7 @@ void DataProcessor::getDataForDiagram(const JPetEvent &event)
                                             .getPoints(JPetSigCh::Leading)[0]
                                             .getPM()
                                             .getBarrelSlot());
+    // calculate position in (r, fi) domain from (x,y)
     double r =
         sqrt(hit.getPosX() * hit.getPosX() + hit.getPosY() * hit.getPosY());
     double fi = hit.getPosX() >= 0 ? asin(hit.getPosY() / r)
@@ -295,19 +296,19 @@ void DataProcessor::getDataForDiagram(const JPetEvent &event)
 
 void DataProcessor::getHitsPosition(const JPetHit &hitSignal)
 {
-  HitPositions hits;
-  hits.push_back(hitSignal.getPos());
-  ProcessedData::getInstance().setHits(hits);
+  HitPositions hitsPos;
+  hitsPos.push_back(hitSignal.getPos());
+  ProcessedData::getInstance().setHits(hitsPos);
 }
 
 void DataProcessor::getHitsPosition(const JPetEvent &event)
 {
-  HitPositions hits;
+  HitPositions hitsPos;
   for (JPetHit hit : event.getHits())
   {
-    hits.push_back(hit.getPos());
+    hitsPos.push_back(hit.getPos());
   }
-  ProcessedData::getInstance().setHits(hits);
+  ProcessedData::getInstance().setHits(hitsPos);
 }
 
 bool DataProcessor::openFile(const char *filename)
@@ -320,11 +321,11 @@ bool DataProcessor::openFile(const char *filename)
     compareMap["JPetHit"] = FileTypes::fHit;
     compareMap["JPetEvent"] = FileTypes::fEvent;
   }
-  bool r = fReader.openFileAndLoadData(filename);
+  bool openFileResult = fReader.openFileAndLoadData(filename);
   dynamic_cast< JPetParamBank * >(fReader.getObjectFromFile(
       "ParamBank")); // just read param bank, no need to save it to variable
   fNumberOfEventsInFile = fReader.getNbOfAllEvents();
-  if (r)
+  if (openFileResult)
   {
     TTree *fTree = dynamic_cast< TTree * >(fReader.getObjectFromFile("tree"));
     TObjArray *arr = fTree->GetListOfBranches();
@@ -333,7 +334,7 @@ bool DataProcessor::openFile(const char *filename)
     ProcessedData::getInstance().setCurrentFileType(
         static_cast< FileTypes >(compareMap[branchName]));
   }
-  return r;
+  return openFileResult;
 }
 
 void DataProcessor::closeFile() { fReader.closeFile(); }

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -228,21 +228,30 @@ DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal,
   StripPos pos = fMapper->getStripPos(
       rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getBarrelSlot());
   auto data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
+  float startPos = data.begin()->second.second;
+  float diff[4];
+  int i = 0;
   for (auto it = data.begin(); it != data.end(); it++)
   {
-
+    diff[i] = startPos - it->second.second;
+    if (diff[i] > 0)
+      diff[i] = -diff[i];
     r.push_back(std::make_tuple(
-        it->first, it->second.first, it->second.second, JPetSigCh::Leading,
+        it->first, it->second.first, startPos, JPetSigCh::Leading,
         rawSignal.getPoints(JPetSigCh::Leading)[0].getPM().getSide(), pos.layer,
         pos.slot));
+    i++;
   }
+  i = 0;
   auto tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
     r.push_back(std::make_tuple(
-        it->first, it->second.first, it->second.second, JPetSigCh::Trailing,
+        it->first, it->second.first, it->second.second - diff[i],
+        JPetSigCh::Trailing,
         rawSignal.getPoints(JPetSigCh::Trailing)[0].getPM().getSide(),
         pos.layer, pos.slot));
+    i++;
   }
   return r;
 }

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -194,15 +194,22 @@ DataProcessor::getActiveScintillators(const JPetEvent &event)
 
 DiagramDataMap DataProcessor::getDataForDiagram(const JPetRawSignal &rawSignal)
 {
-  DiagramDataMap data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
-  DiagramDataMap tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
+  DiagramDataMap r;
+  auto data = rawSignal.getTimesVsThresholdValue(JPetSigCh::Leading);
+  for (auto it = data.begin(); it != data.end(); it++)
+  {
+    r.push_back(std::make_tuple(it->first, it->second.first,
+                                it->second.second, JPetSigCh::Leading));
+  }
+  auto tmp = rawSignal.getTimesVsThresholdValue(JPetSigCh::Trailing);
   int dataSize = data.size();
   for (auto it = tmp.begin(); it != tmp.end(); it++)
   {
-    data[it->first + dataSize] = it->second;
+    r.push_back(std::make_tuple(it->first, it->second.first,
+                                it->second.second, JPetSigCh::Trailing));
   }
 
-  return data;
+  return r;
 }
 
 DiagramDataMapVector DataProcessor::getDataForDiagram(const JPetHit &hitSignal)

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -25,7 +25,7 @@ DataProcessor::DataProcessor()
       << "\n";
   JPetParamManager fparamManagerInstance(
       new JPetParamGetterAscii("large_barrel.json"));
-  fparamManagerInstance.fillParameterBank(43);
+  fparamManagerInstance.fillParameterBank(44);
   auto bank = fparamManagerInstance.getParamBank();
   fMapper = std::unique_ptr< JPetGeomMapping >(new JPetGeomMapping(bank));
 }

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -100,6 +100,7 @@ public:
   bool nextEvent();
   bool lastEvent();
   bool nthEvent(long long n);
+  long long getNumberOfEvents() { return fNumberOfEventsInFile; }
 
 private:
   #ifndef __CINT__

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -16,7 +16,7 @@
 #define DATAPROCESSOR_H
 
 #include <map>
-#include <sstream> //TO delete
+#include <sstream>
 #include <string>
 #include <vector>
 #include <memory>

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -110,7 +110,7 @@ private:
 class DataProcessor
 {
 public:
-  DataProcessor();
+  DataProcessor(const std::string paramGetterAnsiiPath, const int runNumber);
   void getDataForCurrentEvent();
   bool openFile(const char *filename);
   void closeFile();

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -34,17 +34,19 @@
 #endif
 
 #include <TNamed.h>
+#include <TVector3.h>
 
 namespace jpet_event_display
 {
 enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit, fEvent };
 
-typedef std::map<size_t, std::vector<size_t> > ScintillatorsInLayers;
+typedef std::map<size_t, std::vector<size_t>> ScintillatorsInLayers; //layer, scinID, hitPos
 typedef std::vector<std::tuple<int, float, float, JPetSigCh::EdgeType>>
     DiagramDataMap;
 // typedef std::map<int, std::tuple<float, float, JPetSigCh::EdgeType>>
 //    DiagramDataMap; //threshold number, thresholdValue, time, EdgeType
 typedef std::vector<DiagramDataMap> DiagramDataMapVector;
+typedef std::vector<TVector3> HitPositions; //rename
 
 class ProcessedData 
 {
@@ -58,9 +60,21 @@ public:
     return fSingleton; 
   }
 
+  void clearData() {
+    fActivedScins.clear();
+    fDiagram.clear();
+    fHits.clear();
+  }
+
   void setActivedScins(ScintillatorsInLayers scins) { fActivedScins = scins; }
   void setDiagram(DiagramDataMapVector diagram) { fDiagram = diagram; }
   void setCurrentFileType(FileTypes type) { fCurrentFileType = type; }
+  void setHits(HitPositions hits) { fHits = hits; }
+
+  inline FileTypes getCurrentFileType() { return fCurrentFileType; }
+  inline ScintillatorsInLayers& getActivedScintilators() { return fActivedScins; }
+  inline DiagramDataMapVector& getDiagramData() { return fDiagram; }
+  inline HitPositions& getHits() { return fHits; }
 
   const std::string getActivedScintilatorsString()
   {
@@ -78,16 +92,13 @@ public:
     return oss.str();
   }
 
-  inline FileTypes getCurrentFileType() { return fCurrentFileType; }
-  inline ScintillatorsInLayers getActivedScintilators() { return fActivedScins; }
-  inline DiagramDataMapVector getDiagramData() { return fDiagram; }
 private:
   ProcessedData() { }
 
   ScintillatorsInLayers fActivedScins;
   DiagramDataMapVector fDiagram;
+  HitPositions fHits; //rename
   FileTypes fCurrentFileType = FileTypes::fNone;
-
 };
 
 class DataProcessor {
@@ -107,13 +118,19 @@ private:
   DataProcessor(const DataProcessor&) = delete;
   DataProcessor& operator=(const DataProcessor&) = delete;
 
-  ScintillatorsInLayers getActiveScintillators(const JPetTimeWindow& tWindow);
-  ScintillatorsInLayers getActiveScintillators(const JPetRawSignal& rawSignal);
-  ScintillatorsInLayers getActiveScintillators(const JPetHit &hitSignal);
-  ScintillatorsInLayers getActiveScintillators(const JPetEvent &event);
-  DiagramDataMap getDataForDiagram(const JPetRawSignal &rawSignal);
-  DiagramDataMapVector getDataForDiagram(const JPetHit &hitSignal);
-  DiagramDataMapVector getDataForDiagram(const JPetEvent &event);
+  void getActiveScintillators(const JPetTimeWindow &tWindow);
+  void getActiveScintillators(const JPetRawSignal &rawSignal);
+  void getActiveScintillators(const JPetHit &hitSignal);
+  void getActiveScintillators(const JPetEvent &event);
+
+  DiagramDataMap getDataForDiagram(const JPetRawSignal &rawSignal, bool);
+  // void getDataForDiagram(const JPetTimeWindow &tWindow);
+  void getDataForDiagram(const JPetRawSignal &rawSignal);
+  void getDataForDiagram(const JPetHit &hitSignal);
+  void getDataForDiagram(const JPetEvent &event);
+
+  void getHitsPosition(const JPetHit &hitSignal);
+  void getHitsPosition(const JPetEvent &event);
 
   template <typename T> const T &getCurrentEvent();
 

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -54,10 +54,8 @@ typedef std::vector< std::tuple< int, float, float, JPetSigCh::EdgeType,
                                  JPetPM::Side, size_t, size_t > >
     DiagramDataMap; // threshold number, thresholdValue, time, EdgeType, Side,
                     // layer, scin
-// typedef std::map<int, std::tuple<float, float, JPetSigCh::EdgeType>>
-//    DiagramDataMap;
 typedef std::vector< DiagramDataMap > DiagramDataMapVector;
-typedef std::vector< TVector3 > HitPositions; // rename
+typedef std::vector< TVector3 > HitPositions;
 
 class ProcessedData
 {
@@ -85,7 +83,7 @@ public:
   void setCurrentFileType(FileTypes type) { fCurrentFileType = type; }
   void setHits(HitPositions hits) { fHits = hits; }
 
-  inline FileTypes getCurrentFileType() { return fCurrentFileType; }
+  inline FileTypes getCurrentFileType() const { return fCurrentFileType; }
   inline ScintillatorsInLayers &getActivedScintilators()
   {
     return fActivedScins;
@@ -103,7 +101,7 @@ private:
   std::string fInfo;
   ScintillatorsInLayers fActivedScins;
   DiagramDataMapVector fDiagram;
-  HitPositions fHits; // rename
+  HitPositions fHits;
   FileTypes fCurrentFileType = FileTypes::fNone;
 };
 

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -40,8 +40,11 @@ namespace jpet_event_display
 enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit, fEvent };
 
 typedef std::map<size_t, std::vector<size_t> > ScintillatorsInLayers;
-typedef std::map<int, std::pair<float, float>> DiagramDataMap;
-typedef std::vector<std::map<int, std::pair<float, float>>> DiagramDataMapVector;
+typedef std::vector<std::tuple<int, float, float, JPetSigCh::EdgeType>>
+    DiagramDataMap;
+// typedef std::map<int, std::tuple<float, float, JPetSigCh::EdgeType>>
+//    DiagramDataMap; //threshold number, thresholdValue, time, EdgeType
+typedef std::vector<DiagramDataMap> DiagramDataMapVector;
 
 class ProcessedData 
 {

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -30,21 +30,20 @@
 #include <JPetReader/JPetReader.h>
 #include <JPetTimeWindow/JPetTimeWindow.h>
 #include <JPetTreeHeader/JPetTreeHeader.h>
+#include <JPetHit/JPetHit.h>
 #endif
 
 namespace jpet_event_display
 {
-enum FileTypes { fNone, fTimeWindow, fRawSignal };
+enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit };
 
-typedef std::map<int, std::vector<int> > ScintillatorsInLayers;
+typedef std::map<size_t, std::vector<size_t> > ScintillatorsInLayers;
 typedef std::map<int, std::pair<float, float>> DiagramDataMap;
+typedef std::vector<std::map<int, std::pair<float, float>>> DiagramDataMapVector;
 
 class ProcessedData 
 {
-  friend class DataProcessor;
-
 public:
-
   ProcessedData(const ProcessedData&) = delete;
   ProcessedData& operator=(const ProcessedData&) = delete;
   ~ProcessedData() { }
@@ -55,7 +54,7 @@ public:
   }
 
   void setActivedScins(ScintillatorsInLayers scins) { fActivedScins = scins; }
-  void setDiagram(DiagramDataMap diagram) { fDiagram = diagram; }
+  void setDiagram(DiagramDataMapVector diagram) { fDiagram = diagram; }
   void setCurrentFileType(FileTypes type) { fCurrentFileType = type; }
 
   const std::string getActivedScintilatorsString()
@@ -64,7 +63,7 @@ public:
     for (auto iter = fActivedScins.begin(); iter != fActivedScins.end(); ++iter)
     {
       int layer = iter->first;
-      const std::vector<int> &strips = iter->second;
+      const std::vector<size_t> &strips = iter->second;
       for (auto stripIter = strips.begin(); stripIter != strips.end();
            ++stripIter)
       {
@@ -76,15 +75,13 @@ public:
 
   inline FileTypes getCurrentFileType() { return fCurrentFileType; }
   inline ScintillatorsInLayers getActivedScintilators() { return fActivedScins; }
-  inline DiagramDataMap getDiagramData() { return fDiagram; }
+  inline DiagramDataMapVector getDiagramData() { return fDiagram; }
 private:
   ProcessedData() { }
 
-
   ScintillatorsInLayers fActivedScins;
-  DiagramDataMap fDiagram;
+  DiagramDataMapVector fDiagram;
   FileTypes fCurrentFileType = FileTypes::fNone;
-
 
 };
 
@@ -106,7 +103,9 @@ private:
 
   ScintillatorsInLayers getActiveScintillators(const JPetTimeWindow& tWindow);
   ScintillatorsInLayers getActiveScintillators(const JPetRawSignal& rawSignal);
+  ScintillatorsInLayers getActiveScintillators(const JPetHit &hitSignal);
   DiagramDataMap getDataForDiagram(const JPetRawSignal &rawSignal);
+  DiagramDataMapVector getDataForDiagram(const JPetHit &hitSignal);
 
   template <typename T> const T &getCurrentEvent();
 

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -33,9 +33,11 @@
 #include <JPetHit/JPetHit.h>
 #endif
 
+#include <TNamed.h>
+
 namespace jpet_event_display
 {
-enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit };
+enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit, fEvent };
 
 typedef std::map<size_t, std::vector<size_t> > ScintillatorsInLayers;
 typedef std::map<int, std::pair<float, float>> DiagramDataMap;
@@ -104,8 +106,10 @@ private:
   ScintillatorsInLayers getActiveScintillators(const JPetTimeWindow& tWindow);
   ScintillatorsInLayers getActiveScintillators(const JPetRawSignal& rawSignal);
   ScintillatorsInLayers getActiveScintillators(const JPetHit &hitSignal);
+  ScintillatorsInLayers getActiveScintillators(const JPetEvent &event);
   DiagramDataMap getDataForDiagram(const JPetRawSignal &rawSignal);
   DiagramDataMapVector getDataForDiagram(const JPetHit &hitSignal);
+  DiagramDataMapVector getDataForDiagram(const JPetEvent &event);
 
   template <typename T> const T &getCurrentEvent();
 

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -16,21 +16,21 @@
 #define DATAPROCESSOR_H
 
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
 #ifndef __CINT__
 #include <JPetGeomMapping/JPetGeomMapping.h>
 #include <JPetGeomMappingInterface/JPetGeomMappingInterface.h>
+#include <JPetHit/JPetHit.h>
+#include <JPetParamBank/JPetParamBank.h>
 #include <JPetParamGetterAscii/JPetParamGetterAscii.h>
 #include <JPetParamManager/JPetParamManager.h>
-#include <JPetParamBank/JPetParamBank.h>
 #include <JPetRawSignal/JPetRawSignal.h>
 #include <JPetReader/JPetReader.h>
 #include <JPetTimeWindow/JPetTimeWindow.h>
 #include <JPetTreeHeader/JPetTreeHeader.h>
-#include <JPetHit/JPetHit.h>
 #endif
 
 #include <TNamed.h>
@@ -38,29 +38,39 @@
 
 namespace jpet_event_display
 {
-enum FileTypes { fNone, fTimeWindow, fRawSignal, fHit, fEvent };
+enum FileTypes
+{
+  fNone,
+  fTimeWindow,
+  fRawSignal,
+  fHit,
+  fEvent
+};
 
-typedef std::map<size_t, std::vector<size_t>> ScintillatorsInLayers; //layer, scinID, hitPos
-typedef std::vector<std::tuple<int, float, float, JPetSigCh::EdgeType>>
+typedef std::map< size_t, std::vector< size_t > >
+    ScintillatorsInLayers; // layer, scinID, hitPos
+typedef std::vector< std::tuple< int, float, float, JPetSigCh::EdgeType > >
     DiagramDataMap;
 // typedef std::map<int, std::tuple<float, float, JPetSigCh::EdgeType>>
 //    DiagramDataMap; //threshold number, thresholdValue, time, EdgeType
-typedef std::vector<DiagramDataMap> DiagramDataMapVector;
-typedef std::vector<TVector3> HitPositions; //rename
+typedef std::vector< DiagramDataMap > DiagramDataMapVector;
+typedef std::vector< TVector3 > HitPositions; // rename
 
-class ProcessedData 
+class ProcessedData
 {
 public:
-  ProcessedData(const ProcessedData&) = delete;
-  ProcessedData& operator=(const ProcessedData&) = delete;
-  ~ProcessedData() { }
+  ProcessedData(const ProcessedData &) = delete;
+  ProcessedData &operator=(const ProcessedData &) = delete;
+  ~ProcessedData() {}
 
-  static inline ProcessedData & getInstance() {
+  static inline ProcessedData &getInstance()
+  {
     static ProcessedData fSingleton;
-    return fSingleton; 
+    return fSingleton;
   }
 
-  void clearData() {
+  void clearData()
+  {
     fActivedScins.clear();
     fDiagram.clear();
     fHits.clear();
@@ -72,9 +82,12 @@ public:
   void setHits(HitPositions hits) { fHits = hits; }
 
   inline FileTypes getCurrentFileType() { return fCurrentFileType; }
-  inline ScintillatorsInLayers& getActivedScintilators() { return fActivedScins; }
-  inline DiagramDataMapVector& getDiagramData() { return fDiagram; }
-  inline HitPositions& getHits() { return fHits; }
+  inline ScintillatorsInLayers &getActivedScintilators()
+  {
+    return fActivedScins;
+  }
+  inline DiagramDataMapVector &getDiagramData() { return fDiagram; }
+  inline HitPositions &getHits() { return fHits; }
 
   const std::string getActivedScintilatorsString()
   {
@@ -82,7 +95,7 @@ public:
     for (auto iter = fActivedScins.begin(); iter != fActivedScins.end(); ++iter)
     {
       int layer = iter->first;
-      const std::vector<size_t> &strips = iter->second;
+      const std::vector< size_t > &strips = iter->second;
       for (auto stripIter = strips.begin(); stripIter != strips.end();
            ++stripIter)
       {
@@ -93,19 +106,20 @@ public:
   }
 
 private:
-  ProcessedData() { }
+  ProcessedData() {}
 
   ScintillatorsInLayers fActivedScins;
   DiagramDataMapVector fDiagram;
-  HitPositions fHits; //rename
+  HitPositions fHits; // rename
   FileTypes fCurrentFileType = FileTypes::fNone;
 };
 
-class DataProcessor {
+class DataProcessor
+{
 public:
-  DataProcessor() {}
+  DataProcessor();
   void getDataForCurrentEvent();
-  bool openFile(const char* filename);
+  bool openFile(const char *filename);
   void closeFile();
   bool firstEvent();
   bool nextEvent();
@@ -114,9 +128,9 @@ public:
   long long getNumberOfEvents() { return fNumberOfEventsInFile; }
 
 private:
-  #ifndef __CINT__
-  DataProcessor(const DataProcessor&) = delete;
-  DataProcessor& operator=(const DataProcessor&) = delete;
+#ifndef __CINT__
+  DataProcessor(const DataProcessor &) = delete;
+  DataProcessor &operator=(const DataProcessor &) = delete;
 
   void getActiveScintillators(const JPetTimeWindow &tWindow);
   void getActiveScintillators(const JPetRawSignal &rawSignal);
@@ -132,15 +146,14 @@ private:
   void getHitsPosition(const JPetHit &hitSignal);
   void getHitsPosition(const JPetEvent &event);
 
-  template <typename T> const T &getCurrentEvent();
+  template < typename T > const T &getCurrentEvent();
 
   long long fNumberOfEventsInFile = 0;
 
   JPetReader fReader;
-  std::unique_ptr<JPetGeomMapping> fMapper;
-  #endif
+  std::unique_ptr< JPetGeomMapping > fMapper;
+#endif
 };
-
 }
 
 #endif /*  !DATAPROCESSOR_H */

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -24,6 +24,7 @@
 #include <JPetGeomMapping/JPetGeomMapping.h>
 #include <JPetGeomMappingInterface/JPetGeomMappingInterface.h>
 #include <JPetHit/JPetHit.h>
+#include <JPetPM/JPetPM.h>
 #include <JPetParamBank/JPetParamBank.h>
 #include <JPetParamGetterAscii/JPetParamGetterAscii.h>
 #include <JPetParamManager/JPetParamManager.h>
@@ -49,10 +50,12 @@ enum FileTypes
 
 typedef std::map< size_t, std::vector< size_t > >
     ScintillatorsInLayers; // layer, scinID, hitPos
-typedef std::vector< std::tuple< int, float, float, JPetSigCh::EdgeType > >
-    DiagramDataMap;
+typedef std::vector< std::tuple< int, float, float, JPetSigCh::EdgeType,
+                                 JPetPM::Side, size_t, size_t > >
+    DiagramDataMap; // threshold number, thresholdValue, time, EdgeType, Side,
+                    // layer, scin
 // typedef std::map<int, std::tuple<float, float, JPetSigCh::EdgeType>>
-//    DiagramDataMap; //threshold number, thresholdValue, time, EdgeType
+//    DiagramDataMap;
 typedef std::vector< DiagramDataMap > DiagramDataMapVector;
 typedef std::vector< TVector3 > HitPositions; // rename
 
@@ -74,6 +77,7 @@ public:
     fActivedScins.clear();
     fDiagram.clear();
     fHits.clear();
+    fInfo.clear();
   }
 
   void setActivedScins(ScintillatorsInLayers scins) { fActivedScins = scins; }
@@ -89,25 +93,14 @@ public:
   inline DiagramDataMapVector &getDiagramData() { return fDiagram; }
   inline HitPositions &getHits() { return fHits; }
 
-  const std::string getActivedScintilatorsString()
-  {
-    std::ostringstream oss;
-    for (auto iter = fActivedScins.begin(); iter != fActivedScins.end(); ++iter)
-    {
-      int layer = iter->first;
-      const std::vector< size_t > &strips = iter->second;
-      for (auto stripIter = strips.begin(); stripIter != strips.end();
-           ++stripIter)
-      {
-        oss << "layer: " << layer << " scin: " << *stripIter << "\n";
-      }
-    }
-    return oss.str();
-  }
+  inline void addToInfo(const std::string &str) { fInfo += str; }
+
+  const std::string &getInfo() { return fInfo; }
 
 private:
   ProcessedData() {}
 
+  std::string fInfo;
   ScintillatorsInLayers fActivedScins;
   DiagramDataMapVector fDiagram;
   HitPositions fHits; // rename
@@ -136,6 +129,7 @@ private:
   void getActiveScintillators(const JPetRawSignal &rawSignal);
   void getActiveScintillators(const JPetHit &hitSignal);
   void getActiveScintillators(const JPetEvent &event);
+  std::string currentActivedScintillatorsInfo();
 
   DiagramDataMap getDataForDiagram(const JPetRawSignal &rawSignal, bool);
   // void getDataForDiagram(const JPetTimeWindow &tWindow);

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -125,6 +125,9 @@ private:
   DataProcessor(const DataProcessor &) = delete;
   DataProcessor &operator=(const DataProcessor &) = delete;
 
+  void addToSelectionIfNotPresent(ScintillatorsInLayers &selection,
+                                  StripPos &pos);
+
   void getActiveScintillators(const JPetTimeWindow &tWindow);
   void getActiveScintillators(const JPetRawSignal &rawSignal);
   void getActiveScintillators(const JPetHit &hitSignal);

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -108,7 +108,7 @@ private:
 class DataProcessor
 {
 public:
-  DataProcessor(const std::string paramGetterAnsiiPath, const int runNumber);
+  DataProcessor(const std::string &paramGetterAnsiiPath, const int runNumber);
   void getDataForCurrentEvent();
   bool openFile(const char *filename);
   void closeFile();

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -229,7 +229,7 @@ void EventDisplay::AddTab(std::unique_ptr< TGTab > &pTabViews,
 {
   TGCompositeFrame *tabView = pTabViews->AddTab(tabName);
   tabView->ChangeBackground(fFrameBackgroundColor);
-
+  gStyle->SetCanvasPreferGL(kTRUE);
   saveCanvasPtr = std::unique_ptr< TRootEmbeddedCanvas >(
       new TRootEmbeddedCanvas(canvasName, tabView, 600, 600));
   tabView->AddFrame(

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -273,6 +273,7 @@ void EventDisplay::handleMenu(Int_t id)
       assert(visualizator);
       visualizator->loadGeometry(fFileInfo->fFilename);
       visualizator->drawOnlyGeometry();
+      showData();
     }
     break;
     case E_OpenData:
@@ -285,19 +286,7 @@ void EventDisplay::handleMenu(Int_t id)
         return;
       assert(dataProcessor);
       dataProcessor->openFile(fFileInfo->fFilename);
-      /*switch(dataProcessor->getCurrentFileType())
-      {
-        case DataProcessor::FileTypes::fTimeWindow:
-          AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view", "2dViewCanvas");
-          break;
-        case DataProcessor::FileTypes::fRawSignal:
-          AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view", "2dViewCanvas");
-          AddTab(fDisplayTabView, visualizator->getCanvasDiagrams(), "Diagram view", "diagramCanvas");
-          break;
-        default:
-          break;
-      }*/
-      drawSelectedStrips();
+      showData();
     }
     break;
     case E_Close:
@@ -335,14 +324,12 @@ void EventDisplay::showData()
   dataProcessor->nthEvent(fGUIControls->eventNo);
   drawSelectedStrips();
   updateProgressBar();
-  fInputInfo->ChangeText(dataProcessor->getDataInfo().c_str());
+  fInputInfo->ChangeText(ProcessedData::getInstance().getActivedScintilatorsString().c_str());
 }
 
 void EventDisplay::drawSelectedStrips()
 {
-  std::map<int, std::vector<int> > selection = dataProcessor->getActiveScintillators();
-  visualizator->drawStrips(selection);
-  visualizator->drawDiagram(dataProcessor->getDataForDiagram());
+  visualizator->drawData();
 }
 
 void EventDisplay::setMaxProgressBar (Int_t maxEvent) {

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -41,7 +41,7 @@ EventDisplay::~EventDisplay() { fMainWindow->Cleanup(); }
 void EventDisplay::run()
 {
   fMainWindow =
-      std::unique_ptr<TGMainFrame>(new TGMainFrame(gClient->GetRoot()));
+      std::unique_ptr< TGMainFrame >(new TGMainFrame(gClient->GetRoot()));
   fMainWindow->SetCleanup(kDeepCleanup);
   fMainWindow->Connect("CloseWindow()", "jpet_event_display::EventDisplay",
                        this, "CloseWindow()");
@@ -94,7 +94,7 @@ void EventDisplay::run()
 
 void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
 {
-  fDisplayTabView = std::unique_ptr<TGTab>(new TGTab(parentFrame, 1, 1));
+  fDisplayTabView = std::unique_ptr< TGTab >(new TGTab(parentFrame, 1, 1));
   fDisplayTabView->ChangeBackground(fFrameBackgroundColor);
 
   AddTab(fDisplayTabView, visualizator->getCanvas3d(), "3d view",
@@ -133,7 +133,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
       new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
   markersCheck->ChangeBackground(fFrameBackgroundColor);
   markersCheck->Connect("Clicked()", "jpet_event_display::EventDisplay", this,
-                       "checkBoxMarkersSignalFunction()");
+                        "checkBoxMarkersSignalFunction()");
 
   TGCompositeFrame *frame1_2 =
       AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
@@ -148,7 +148,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
   TGCompositeFrame *tabFrame1 = AddCompositeFrame(
       tf1, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 5, 5, 5, 5);
 
-  fInputInfo = std::unique_ptr<TGLabel>(new TGLabel(
+  fInputInfo = std::unique_ptr< TGLabel >(new TGLabel(
       tabFrame1, "No file read.", TGLabel::GetDefaultGC()(),
       TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor));
   fInputInfo->SetTextJustify(kTextTop | kTextLeft);
@@ -187,7 +187,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
 
   int fMaxEvents = 1000; // temporary
 
-  fNumberEntryStep = std::unique_ptr<TGNumberEntry>(
+  fNumberEntryStep = std::unique_ptr< TGNumberEntry >(
       new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
                         TGNumberFormat::kNEAPositive,
                         TGNumberFormat::kNELLimitMinMax, 1, fMaxEvents));
@@ -204,7 +204,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
   frame1_3_2->AddFrame(labelEventNo,
                        new TGLayoutHints(kLHintsLeft | kLHintsTop, 2, 2, 2, 2));
 
-  fNumberEntryEventNo = std::unique_ptr<TGNumberEntry>(
+  fNumberEntryEventNo = std::unique_ptr< TGNumberEntry >(
       new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
                         TGNumberFormat::kNEANonNegative,
                         TGNumberFormat::kNELLimitMinMax, 0, fMaxEvents));
@@ -214,7 +214,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
                                "jpet_event_display::EventDisplay", this,
                                "updateGUIControlls()");
 
-  fProgBar = std::unique_ptr<TGHProgressBar>(
+  fProgBar = std::unique_ptr< TGHProgressBar >(
       new TGHProgressBar(frame1_3, TGProgressBar::kFancy, 250));
   fProgBar->SetBarColor("lightblue");
   fProgBar->ShowPosition(kTRUE, kFALSE, "%.0f events");
@@ -223,14 +223,14 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
                      new TGLayoutHints(kLHintsCenterX, 5, 5, 3, 4));
 }
 
-void EventDisplay::AddTab(std::unique_ptr<TGTab> &pTabViews,
-                          std::unique_ptr<TRootEmbeddedCanvas> &saveCanvasPtr,
+void EventDisplay::AddTab(std::unique_ptr< TGTab > &pTabViews,
+                          std::unique_ptr< TRootEmbeddedCanvas > &saveCanvasPtr,
                           const char *tabName, const char *canvasName)
 {
   TGCompositeFrame *tabView = pTabViews->AddTab(tabName);
   tabView->ChangeBackground(fFrameBackgroundColor);
 
-  saveCanvasPtr = std::unique_ptr<TRootEmbeddedCanvas>(
+  saveCanvasPtr = std::unique_ptr< TRootEmbeddedCanvas >(
       new TRootEmbeddedCanvas(canvasName, tabView, 600, 600));
   tabView->AddFrame(
       saveCanvasPtr.get(),
@@ -376,8 +376,7 @@ void EventDisplay::showData()
   dataProcessor->nthEvent(fGUIControls->eventNo);
   drawSelectedStrips();
   updateProgressBar();
-  fInputInfo->ChangeText(
-      ProcessedData::getInstance().getActivedScintilatorsString().c_str());
+  fInputInfo->ChangeText(ProcessedData::getInstance().getInfo().c_str());
 }
 
 void EventDisplay::drawSelectedStrips() { visualizator->drawData(); }
@@ -391,14 +390,14 @@ void EventDisplay::setMaxProgressBar(Int_t maxEvent)
 void EventDisplay::startVirtualization()
 {
   startVirtualizationLoop(10);
-  //std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
-  //t.join();
+  // std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
+  // t.join();
 }
 
 void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
 {
   long long maxEvent = dataProcessor->getNumberOfEvents();
-  for(int i = 0; i < 100 && fGUIControls->eventNo < maxEvent; i++)
+  for (int i = 0; i < 100 && fGUIControls->eventNo < maxEvent; i++)
   {
     doNext();
     std::this_thread::sleep_for(std::chrono::milliseconds(waitTimeInMs));

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -86,7 +86,7 @@ void EventDisplay::run()
   globalFrame->Resize(globalFrame->GetDefaultSize());
   baseFrame->Resize(baseFrame->GetDefaultSize());
 
-  fMainWindow->SetWindowName("Single Strip Event Display ver 0.1");
+  fMainWindow->SetWindowName("Event Display ver 0.2");
   fMainWindow->MapSubwindows();
   fMainWindow->Resize(fMainWindow->GetDefaultSize());
   fMainWindow->MapWindow();

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -147,6 +147,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame* parentFrame)
   AddButton(frame1_3_1, "&Next >", "doNext()");
   AddButton(frame1_3_1, "&Reset >", "doReset()");
   AddButton(frame1_3_1, "Show Data", "showData()");
+  AddButton(frame1_3_1, "Start Virt", "startVirtualization()");
 
   TGCompositeFrame *frame1_3_2 =
     AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame, kLHintsExpandX| kLHintsTop, 5, 5, 5, 5);
@@ -288,6 +289,7 @@ void EventDisplay::handleMenu(Int_t id)
       assert(dataProcessor);
       dataProcessor->openFile(fFileInfo->fFilename);
       showData();
+      setMaxProgressBar(dataProcessor->getNumberOfEvents());
     }
     break;
     case E_Close:
@@ -338,4 +340,20 @@ void EventDisplay::setMaxProgressBar (Int_t maxEvent) {
   fProgBar->SetRange(0.0f,Float_t(maxEvent));
 }
 
+void EventDisplay::startVirtualization()
+{
+  std::thread t(&EventDisplay::startVirtualizationLoop, this, 1000);
+  t.join();
+}
+
+void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
+{
+  doReset();
+  long long maxEvent = dataProcessor->getNumberOfEvents();
+  while (fGUIControls->eventNo != maxEvent)
+  {
+    doNext();
+    std::this_thread::sleep_for(std::chrono::milliseconds(waitTimeInMs));
+  }
+}
 }

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -99,9 +99,9 @@ void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
 
   AddTab(fDisplayTabView, visualizator->getCanvas3d(), "3d view",
          "3dViewCanvas");
-  AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view",
+  AddTab(fDisplayTabView, visualizator->getCanvas2d(), "Unrolled view",
          "2dViewCanvas");
-  AddTab(fDisplayTabView, visualizator->getCanvasTopView(), "top view",
+  AddTab(fDisplayTabView, visualizator->getCanvasTopView(), "Front view",
          "canvasTopView");
   AddTab(fDisplayTabView, visualizator->getCanvasDiagrams(), "Diagram view",
          "diagramCanvas");

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -20,12 +20,10 @@ namespace jpet_event_display
 {
 
 const char *filetypes[] = {
-    "All files", "*",
-    "ROOT files", "*.root",
-    "Text files", "*.[tT][xX][tT]",
-    0, 0};
+    "All files", "*", "ROOT files", "*.root", "Text files", "*.[tT][xX][tT]",
+    0,           0};
 
-EventDisplay::EventDisplay() 
+EventDisplay::EventDisplay()
 {
   fGUIControls->eventNo = 0;
   fGUIControls->stepNo = 0;
@@ -38,33 +36,38 @@ EventDisplay::EventDisplay()
   INFO("*********************");
 }
 
-EventDisplay::~EventDisplay() {
-  fMainWindow->Cleanup();
-}
+EventDisplay::~EventDisplay() { fMainWindow->Cleanup(); }
 
 void EventDisplay::run()
 {
-  fMainWindow = std::unique_ptr<TGMainFrame>(new TGMainFrame(gClient->GetRoot()));
+  fMainWindow =
+      std::unique_ptr<TGMainFrame>(new TGMainFrame(gClient->GetRoot()));
   fMainWindow->SetCleanup(kDeepCleanup);
-  fMainWindow->Connect("CloseWindow()", "jpet_event_display::EventDisplay", this, "CloseWindow()");
+  fMainWindow->Connect("CloseWindow()", "jpet_event_display::EventDisplay",
+                       this, "CloseWindow()");
   const Int_t w_max = 1024;
   const Int_t h_max = 720;
-  fMainWindow->SetWMSize(w_max, h_max); //this is the only way to set the size of the main frame
+  fMainWindow->SetWMSize(
+      w_max, h_max); // this is the only way to set the size of the main frame
   fMainWindow->SetLayoutBroken(kTRUE);
   assert(fMainWindow != 0);
   const Int_t w_GlobalFrame = w_max;
   const Int_t h_GlobalFrame = h_max;
   const Int_t w_Frame1 = 180;
-  const Int_t h_Frame1 = h_max - 12; // cause 2*5 margins from GlobalFrame and 2*1 margins from Frame1
+  const Int_t h_Frame1 =
+      h_max -
+      12; // cause 2*5 margins from GlobalFrame and 2*1 margins from Frame1
   const Int_t w_Frame2 = w_max - w_Frame1;
   const Int_t h_Frame2 = h_max - 12;
-  
-  TGCompositeFrame *baseFrame =
-      AddCompositeFrame(fMainWindow.get(), w_GlobalFrame, h_GlobalFrame - 10, kVerticalFrame);
-  fMainWindow->AddFrame(baseFrame, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
-  //saving background color in fFrameBackgroundColor
-  gClient->GetColorByName("#e6e6e6", fFrameBackgroundColor); 
+  TGCompositeFrame *baseFrame = AddCompositeFrame(
+      fMainWindow.get(), w_GlobalFrame, h_GlobalFrame - 10, kVerticalFrame);
+  fMainWindow->AddFrame(
+      baseFrame,
+      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+
+  // saving background color in fFrameBackgroundColor
+  gClient->GetColorByName("#e6e6e6", fFrameBackgroundColor);
   baseFrame->ChangeBackground(fFrameBackgroundColor);
 
   AddMenuBar(baseFrame);
@@ -77,7 +80,7 @@ void EventDisplay::run()
   TGGroupFrame *displayFrame =
       AddGroupFrame(globalFrame, "Display", w_Frame2, h_Frame2);
 
-  CreateOptionsFrame(optionsFrame); 
+  CreateOptionsFrame(optionsFrame);
   CreateDisplayFrame(displayFrame);
 
   globalFrame->Resize(globalFrame->GetDefaultSize());
@@ -89,60 +92,73 @@ void EventDisplay::run()
   fMainWindow->MapWindow();
 }
 
-void EventDisplay::CreateDisplayFrame(TGGroupFrame* parentFrame) {
+void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
+{
   fDisplayTabView = std::unique_ptr<TGTab>(new TGTab(parentFrame, 1, 1));
   fDisplayTabView->ChangeBackground(fFrameBackgroundColor);
 
-  AddTab(fDisplayTabView, visualizator->getCanvas3d(), "3d view", "3dViewCanvas");
-  AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view", "2dViewCanvas");
-  AddTab(fDisplayTabView, visualizator->getCanvasDiagrams(), "Diagram view", "diagramCanvas");
+  AddTab(fDisplayTabView, visualizator->getCanvas3d(), "3d view",
+         "3dViewCanvas");
+  AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view",
+         "2dViewCanvas");
+  AddTab(fDisplayTabView, visualizator->getCanvas2d2(), "2d view 2",
+         "2dViewCanvas2");
+  AddTab(fDisplayTabView, visualizator->getCanvasDiagrams(), "Diagram view",
+         "diagramCanvas");
 
   fDisplayTabView->SetEnabled(1, kTRUE);
   parentFrame->AddFrame(
-      fDisplayTabView.get(), new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY,
-                                   2, 2, 5, 1));
+      fDisplayTabView.get(),
+      new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 5,
+                        1));
 }
 
-void EventDisplay::CreateOptionsFrame(TGGroupFrame* parentFrame)
+void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
 {
-  TGCompositeFrame *frame1_1 = 
-    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame, kLHintsExpandX |kLHintsTop, 1, 1, 1, 1);
+  TGCompositeFrame *frame1_1 =
+      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                        kLHintsExpandX | kLHintsTop, 1, 1, 1, 1);
 
-  TGCompositeFrame *frame1_1_2 = 
-    AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame, kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
+  TGCompositeFrame *frame1_1_2 =
+      AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame,
+                        kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
 
-  //AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
+  // AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
   AddButton(frame1_1_2, "Read Data", "handleMenu(=1)");
 
-  TGCompositeFrame *frame1_2 = 
-    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1);
+  TGCompositeFrame *frame1_2 =
+      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                        kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1);
 
-  TGTab* pTab = new TGTab(frame1_2, 1, 1);
+  TGTab *pTab = new TGTab(frame1_2, 1, 1);
   pTab->ChangeBackground(fFrameBackgroundColor);
 
-  TGCompositeFrame* tf1 = pTab->AddTab("Info");
+  TGCompositeFrame *tf1 = pTab->AddTab("Info");
   tf1->ChangeBackground(fFrameBackgroundColor);
 
-  TGCompositeFrame* tabFrame1 = 
-    AddCompositeFrame(tf1, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 5, 5, 5, 5);
+  TGCompositeFrame *tabFrame1 = AddCompositeFrame(
+      tf1, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 5, 5, 5, 5);
 
-  fInputInfo = std::unique_ptr<TGLabel>(new TGLabel(tabFrame1,
-                                        "No file read.",
-                                        TGLabel::GetDefaultGC()(),
-                                        TGLabel::GetDefaultFontStruct(),
-                                        kChildFrame,
-                                        fFrameBackgroundColor));
+  fInputInfo = std::unique_ptr<TGLabel>(new TGLabel(
+      tabFrame1, "No file read.", TGLabel::GetDefaultGC()(),
+      TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor));
   fInputInfo->SetTextJustify(kTextTop | kTextLeft);
-  tabFrame1->AddFrame(fInputInfo.get(), new TGLayoutHints(kLHintsExpandX | kLHintsExpandY,1,1,1,1));
+  tabFrame1->AddFrame(
+      fInputInfo.get(),
+      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1));
 
-  pTab->SetEnabled(1,kTRUE);
-  frame1_2->AddFrame(pTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 5, 1));
+  pTab->SetEnabled(1, kTRUE);
+  frame1_2->AddFrame(
+      pTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2,
+                              2, 5, 1));
 
-  TGCompositeFrame *frame1_3 = 
-    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame, kLHintsExpandX| kLHintsBottom, 2, 2, 2, 2);
+  TGCompositeFrame *frame1_3 =
+      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                        kLHintsExpandX | kLHintsBottom, 2, 2, 2, 2);
 
-  TGCompositeFrame *frame1_3_1 = 
-    AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame, kLHintsExpandX | kLHintsTop, 2, 2, 2, 2);
+  TGCompositeFrame *frame1_3_1 =
+      AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
+                        kLHintsExpandX | kLHintsTop, 2, 2, 2, 2);
 
   AddButton(frame1_3_1, "&Next >", "doNext()");
   AddButton(frame1_3_1, "&Reset >", "doReset()");
@@ -150,43 +166,58 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame* parentFrame)
   AddButton(frame1_3_1, "Start Virt", "startVirtualization()");
 
   TGCompositeFrame *frame1_3_2 =
-    AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame, kLHintsExpandX| kLHintsTop, 5, 5, 5, 5);
+      AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
+                        kLHintsExpandX | kLHintsTop, 5, 5, 5, 5);
 
-  TGLabel *labelStep = new TGLabel(frame1_3_2,"Step",TGLabel::GetDefaultGC()(),TGLabel::GetDefaultFontStruct(),kChildFrame,fFrameBackgroundColor);
+  TGLabel *labelStep = new TGLabel(
+      frame1_3_2, "Step", TGLabel::GetDefaultGC()(),
+      TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
   labelStep->SetTextJustify(36);
-  frame1_3_2->AddFrame(labelStep, new TGLayoutHints(kLHintsLeft | kLHintsTop,2,2,2,2));
+  frame1_3_2->AddFrame(labelStep,
+                       new TGLayoutHints(kLHintsLeft | kLHintsTop, 2, 2, 2, 2));
 
   int fMaxEvents = 1000; // temporary
 
-  fNumberEntryStep = std::unique_ptr<TGNumberEntry>(new TGNumberEntry(frame1_3_2,
-                                                  1, 5, -1, TGNumberFormat::kNESInteger,
-                                                  TGNumberFormat::kNEAPositive,
-                                                  TGNumberFormat::kNELLimitMinMax, 1,fMaxEvents));
-  frame1_3_2->AddFrame(fNumberEntryStep.get(), new TGLayoutHints(kLHintsCenterX,5,5,3,4));
-  fNumberEntryStep->Connect("ValueSet(Long_t)", "jpet_event_display::EventDisplay", this, "updateGUIControlls()");
+  fNumberEntryStep = std::unique_ptr<TGNumberEntry>(
+      new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
+                        TGNumberFormat::kNEAPositive,
+                        TGNumberFormat::kNELLimitMinMax, 1, fMaxEvents));
+  frame1_3_2->AddFrame(fNumberEntryStep.get(),
+                       new TGLayoutHints(kLHintsCenterX, 5, 5, 3, 4));
+  fNumberEntryStep->Connect("ValueSet(Long_t)",
+                            "jpet_event_display::EventDisplay", this,
+                            "updateGUIControlls()");
 
-  TGLabel *labelEventNo = new TGLabel(frame1_3_2,"Event no",TGLabel::GetDefaultGC()(),TGLabel::GetDefaultFontStruct(),kChildFrame,fFrameBackgroundColor);
+  TGLabel *labelEventNo = new TGLabel(
+      frame1_3_2, "Event no", TGLabel::GetDefaultGC()(),
+      TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
   labelEventNo->SetTextJustify(36);
-  frame1_3_2->AddFrame(labelEventNo, new TGLayoutHints(kLHintsLeft | kLHintsTop,2,2,2,2));
+  frame1_3_2->AddFrame(labelEventNo,
+                       new TGLayoutHints(kLHintsLeft | kLHintsTop, 2, 2, 2, 2));
 
-  fNumberEntryEventNo = std::unique_ptr<TGNumberEntry>(new TGNumberEntry(frame1_3_2,
-                                                      1, 5, -1, TGNumberFormat::kNESInteger,
-                                                      TGNumberFormat::kNEANonNegative,
-                                                      TGNumberFormat::kNELLimitMinMax, 0, fMaxEvents));
-  frame1_3_2->AddFrame(fNumberEntryEventNo.get(), new TGLayoutHints(kLHintsExpandX));
-  fNumberEntryEventNo->Connect("ValueSet(Long_t)", "jpet_event_display::EventDisplay", this, "updateGUIControlls()");
+  fNumberEntryEventNo = std::unique_ptr<TGNumberEntry>(
+      new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
+                        TGNumberFormat::kNEANonNegative,
+                        TGNumberFormat::kNELLimitMinMax, 0, fMaxEvents));
+  frame1_3_2->AddFrame(fNumberEntryEventNo.get(),
+                       new TGLayoutHints(kLHintsExpandX));
+  fNumberEntryEventNo->Connect("ValueSet(Long_t)",
+                               "jpet_event_display::EventDisplay", this,
+                               "updateGUIControlls()");
 
-  fProgBar = std::unique_ptr<TGHProgressBar>(new TGHProgressBar(frame1_3,TGProgressBar::kFancy,250));
+  fProgBar = std::unique_ptr<TGHProgressBar>(
+      new TGHProgressBar(frame1_3, TGProgressBar::kFancy, 250));
   fProgBar->SetBarColor("lightblue");
-  fProgBar->ShowPosition(kTRUE,kFALSE,"%.0f events");
-  fProgBar->SetRange(0,fMaxEvents);
-  frame1_3->AddFrame(fProgBar.get(),new TGLayoutHints(kLHintsCenterX,5,5,3,4));
+  fProgBar->ShowPosition(kTRUE, kFALSE, "%.0f events");
+  fProgBar->SetRange(0, fMaxEvents);
+  frame1_3->AddFrame(fProgBar.get(),
+                     new TGLayoutHints(kLHintsCenterX, 5, 5, 3, 4));
 }
 
 void EventDisplay::AddTab(std::unique_ptr<TGTab> &pTabViews,
                           std::unique_ptr<TRootEmbeddedCanvas> &saveCanvasPtr,
-                          const char *tabName,
-                          const char *canvasName) {
+                          const char *tabName, const char *canvasName)
+{
   TGCompositeFrame *tabView = pTabViews->AddTab(tabName);
   tabView->ChangeBackground(fFrameBackgroundColor);
 
@@ -198,8 +229,8 @@ void EventDisplay::AddTab(std::unique_ptr<TGTab> &pTabViews,
 }
 
 void EventDisplay::AddButton(TGCompositeFrame *parentFrame,
-                             const char *buttonText,
-                             const char *signalFunction) {
+                             const char *buttonText, const char *signalFunction)
+{
   TGTextButton *button = new TGTextButton(parentFrame, buttonText);
   parentFrame->AddFrame(
       button, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
@@ -209,9 +240,10 @@ void EventDisplay::AddButton(TGCompositeFrame *parentFrame,
   button->ChangeBackground(fFrameBackgroundColor);
 }
 
-TGGroupFrame* EventDisplay::AddGroupFrame(TGCompositeFrame *parentFrame,
-                                         const char *frameName, Int_t width,
-                                         Int_t height) {
+TGGroupFrame *EventDisplay::AddGroupFrame(TGCompositeFrame *parentFrame,
+                                          const char *frameName, Int_t width,
+                                          Int_t height)
+{
   TGGroupFrame *frame = new TGGroupFrame(
       parentFrame, frameName, kVerticalFrame, TGGroupFrame::GetDefaultGC()(),
       TGGroupFrame::GetDefaultFontStruct(), fFrameBackgroundColor);
@@ -224,8 +256,9 @@ TGGroupFrame* EventDisplay::AddGroupFrame(TGCompositeFrame *parentFrame,
 TGCompositeFrame *EventDisplay::AddCompositeFrame(TGCompositeFrame *parentFrame,
                                                   Int_t width, Int_t height,
                                                   Int_t options, ULong_t hints,
-                                                  Int_t padleft,Int_t padright,
-                                                  Int_t padtop, Int_t padbottom) {
+                                                  Int_t padleft, Int_t padright,
+                                                  Int_t padtop, Int_t padbottom)
+{
   TGCompositeFrame *frame =
       new TGCompositeFrame(parentFrame, width, height, options);
   frame->ChangeBackground(fFrameBackgroundColor);
@@ -239,8 +272,10 @@ void EventDisplay::AddMenuBar(TGCompositeFrame *parentFrame)
   TGMenuBar *fMenuBar = new TGMenuBar(parentFrame, 1, 1, kHorizontalFrame);
   fMenuBar->ChangeBackground(fFrameBackgroundColor);
 
-  TGLayoutHints *fMenuBarItemLayout = new TGLayoutHints(kLHintsTop | kLHintsRight, 0, 0, 0, 0);
-  TGLayoutHints *fMenuBarLayout = new TGLayoutHints(kLHintsLeft | kLHintsTop, 0, 0, 0, 0);
+  TGLayoutHints *fMenuBarItemLayout =
+      new TGLayoutHints(kLHintsTop | kLHintsRight, 0, 0, 0, 0);
+  TGLayoutHints *fMenuBarLayout =
+      new TGLayoutHints(kLHintsLeft | kLHintsTop, 0, 0, 0, 0);
 
   TGPopupMenu *fMenuFile = new TGPopupMenu(gClient->GetRoot());
   fMenuFile->AddEntry(" &Open Geometry...\tCtrl+O", E_OpenGeometry);
@@ -249,7 +284,8 @@ void EventDisplay::AddMenuBar(TGCompositeFrame *parentFrame)
   fMenuFile->AddSeparator();
   fMenuFile->AddEntry(" E&xit\tCtrl+Q", E_Close);
   fMenuFile->Associate(fMainWindow.get());
-  fMenuFile->Connect("Activated(Int_t)", "jpet_event_display::EventDisplay", this, "handleMenu(Int_t)");
+  fMenuFile->Connect("Activated(Int_t)", "jpet_event_display::EventDisplay",
+                     this, "handleMenu(Int_t)");
 
   fMenuFile->DisableEntry(0);
 
@@ -264,50 +300,53 @@ void EventDisplay::handleMenu(Int_t id)
 {
   switch (id)
   {
-    /*case E_OpenGeometry:
-    {
-      TString dir("");
-      fFileInfo->fFileTypes = filetypes;
-      fFileInfo->fIniDir = StrDup(dir);
-      new TGFileDialog(gClient->GetRoot(), fMainWindow.get(), kFDOpen, fFileInfo.get());
-      if(fFileInfo->fFilename == 0)
-        return;
-      assert(visualizator);
-      //visualizator->loadGeometry(fFileInfo->fFilename);
-      //visualizator->drawOnlyGeometry();
-      showData();
-    }
-    break;*/
-    case E_OpenData:
-    {
-      TString dir("");
-      fFileInfo->fFileTypes = filetypes;
-      fFileInfo->fIniDir = StrDup(dir);
-      new TGFileDialog(gClient->GetRoot(), fMainWindow.get(), kFDOpen, fFileInfo.get());
-      if(fFileInfo->fFilename == 0)
-        return;
-      assert(dataProcessor);
-      dataProcessor->openFile(fFileInfo->fFilename);
-      showData();
-      setMaxProgressBar(dataProcessor->getNumberOfEvents());
-    }
-    break;
-    case E_Close:
-    {
-      CloseWindow();
-    }
-    break;
+  /*case E_OpenGeometry:
+  {
+    TString dir("");
+    fFileInfo->fFileTypes = filetypes;
+    fFileInfo->fIniDir = StrDup(dir);
+    new TGFileDialog(gClient->GetRoot(), fMainWindow.get(), kFDOpen,
+  fFileInfo.get());
+    if(fFileInfo->fFilename == 0)
+      return;
+    assert(visualizator);
+    //visualizator->loadGeometry(fFileInfo->fFilename);
+    //visualizator->drawOnlyGeometry();
+    showData();
+  }
+  break;*/
+  case E_OpenData:
+  {
+    TString dir("");
+    fFileInfo->fFileTypes = filetypes;
+    fFileInfo->fIniDir = StrDup(dir);
+    new TGFileDialog(gClient->GetRoot(), fMainWindow.get(), kFDOpen,
+                     fFileInfo.get());
+    if (fFileInfo->fFilename == 0)
+      return;
+    assert(dataProcessor);
+    dataProcessor->openFile(fFileInfo->fFilename);
+    showData();
+    setMaxProgressBar(dataProcessor->getNumberOfEvents());
+  }
+  break;
+  case E_Close:
+  {
+    CloseWindow();
+  }
+  break;
   }
   return;
 }
 
-void EventDisplay::updateGUIControlls() 
+void EventDisplay::updateGUIControlls()
 {
   fGUIControls->eventNo = fNumberEntryEventNo->GetIntNumber();
   fGUIControls->stepNo = fNumberEntryStep->GetIntNumber();
 }
 
-void EventDisplay::doReset() {
+void EventDisplay::doReset()
+{
   fNumberEntryEventNo->SetIntNumber(1);
   fNumberEntryStep->SetIntNumber(1);
   updateProgressBar(0);
@@ -317,7 +356,8 @@ void EventDisplay::doReset() {
 void EventDisplay::doNext()
 {
   updateGUIControlls();
-  fNumberEntryEventNo->SetIntNumber(fGUIControls->eventNo + fGUIControls->stepNo);
+  fNumberEntryEventNo->SetIntNumber(fGUIControls->eventNo +
+                                    fGUIControls->stepNo);
   showData();
 }
 
@@ -327,22 +367,21 @@ void EventDisplay::showData()
   dataProcessor->nthEvent(fGUIControls->eventNo);
   drawSelectedStrips();
   updateProgressBar();
-  fInputInfo->ChangeText(ProcessedData::getInstance().getActivedScintilatorsString().c_str());
+  fInputInfo->ChangeText(
+      ProcessedData::getInstance().getActivedScintilatorsString().c_str());
 }
 
-void EventDisplay::drawSelectedStrips()
+void EventDisplay::drawSelectedStrips() { visualizator->drawData(); }
+
+void EventDisplay::setMaxProgressBar(Int_t maxEvent)
 {
-  visualizator->drawData();
-}
-
-void EventDisplay::setMaxProgressBar (Int_t maxEvent) {
-  fProgBar->Format(Form("%%.0f/%d events",maxEvent));
-  fProgBar->SetRange(0.0f,Float_t(maxEvent));
+  fProgBar->Format(Form("%%.0f/%d events", maxEvent));
+  fProgBar->SetRange(0.0f, Float_t(maxEvent));
 }
 
 void EventDisplay::startVirtualization()
 {
-  std::thread t(&EventDisplay::startVirtualizationLoop, this, 1000);
+  std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
   t.join();
 }
 

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -31,6 +31,7 @@ EventDisplay::EventDisplay()
   fGUIControls->stepNo = 0;
   run();
   updateGUIControlls();
+  visualizator->showGeometry();
   fApplication->Run();
   DATE_AND_TIME();
   INFO("J-PET Event Display created");
@@ -110,7 +111,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame* parentFrame)
   TGCompositeFrame *frame1_1_2 = 
     AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame, kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
 
-  AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
+  //AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
   AddButton(frame1_1_2, "Read Data", "handleMenu(=1)");
 
   TGCompositeFrame *frame1_2 = 
@@ -249,7 +250,7 @@ void EventDisplay::AddMenuBar(TGCompositeFrame *parentFrame)
   fMenuFile->Associate(fMainWindow.get());
   fMenuFile->Connect("Activated(Int_t)", "jpet_event_display::EventDisplay", this, "handleMenu(Int_t)");
 
-  fMenuFile->DisableEntry(1);
+  fMenuFile->DisableEntry(0);
 
   fMenuBar->AddPopup("&File", fMenuFile, fMenuBarItemLayout);
 
@@ -262,7 +263,7 @@ void EventDisplay::handleMenu(Int_t id)
 {
   switch (id)
   {
-    case E_OpenGeometry:
+    /*case E_OpenGeometry:
     {
       TString dir("");
       fFileInfo->fFileTypes = filetypes;
@@ -271,11 +272,11 @@ void EventDisplay::handleMenu(Int_t id)
       if(fFileInfo->fFilename == 0)
         return;
       assert(visualizator);
-      visualizator->loadGeometry(fFileInfo->fFilename);
-      visualizator->drawOnlyGeometry();
+      //visualizator->loadGeometry(fFileInfo->fFilename);
+      //visualizator->drawOnlyGeometry();
       showData();
     }
-    break;
+    break;*/
     case E_OpenData:
     {
       TString dir("");

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -23,8 +23,15 @@ const char *filetypes[] = {
     "All files", "*", "ROOT files", "*.root", "Text files", "*.[tT][xX][tT]",
     0,           0};
 
-EventDisplay::EventDisplay()
+EventDisplay::EventDisplay(
+    const std::string &paramGetterAnsiiPath, const int runNumber,
+    const int numberOfLayers, const int scintillatorLenght,
+    const std::vector< std::pair< int, double > > &layerStats)
 {
+  dataProcessor = std::unique_ptr< DataProcessor >(
+      new DataProcessor(paramGetterAnsiiPath, runNumber));
+  visualizator = std::unique_ptr< GeometryVisualizator >(
+      new GeometryVisualizator(numberOfLayers, scintillatorLenght, layerStats));
   fGUIControls->eventNo = 0;
   fGUIControls->stepNo = 0;
   run();

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -101,8 +101,8 @@ void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
          "3dViewCanvas");
   AddTab(fDisplayTabView, visualizator->getCanvas2d(), "2d view",
          "2dViewCanvas");
-  AddTab(fDisplayTabView, visualizator->getCanvas2d2(), "2d view 2",
-         "2dViewCanvas2");
+  AddTab(fDisplayTabView, visualizator->getCanvasTopView(), "top view",
+         "canvasTopView");
   AddTab(fDisplayTabView, visualizator->getCanvasDiagrams(), "Diagram view",
          "diagramCanvas");
 
@@ -125,6 +125,15 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
 
   // AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
   AddButton(frame1_1_2, "Read Data", "handleMenu(=1)");
+
+  TGCheckButton *markersCheck =
+      new TGCheckButton(frame1_1, "Save markers and lines between events", 1);
+  frame1_1->AddFrame(
+      markersCheck,
+      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
+  markersCheck->ChangeBackground(fFrameBackgroundColor);
+  markersCheck->Connect("Clicked()", "jpet_event_display::EventDisplay", this,
+                       "checkBoxMarkersSignalFunction()");
 
   TGCompositeFrame *frame1_2 =
       AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
@@ -381,18 +390,23 @@ void EventDisplay::setMaxProgressBar(Int_t maxEvent)
 
 void EventDisplay::startVirtualization()
 {
-  std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
-  t.join();
+  startVirtualizationLoop(10);
+  //std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
+  //t.join();
 }
 
 void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
 {
-  doReset();
   long long maxEvent = dataProcessor->getNumberOfEvents();
-  while (fGUIControls->eventNo != maxEvent)
+  for(int i = 0; i < 100 && fGUIControls->eventNo < maxEvent; i++)
   {
     doNext();
     std::this_thread::sleep_for(std::chrono::milliseconds(waitTimeInMs));
   }
+}
+
+void EventDisplay::checkBoxMarkersSignalFunction()
+{
+  visualizator->changeMarkersState();
 }
 }

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -86,7 +86,7 @@ void EventDisplay::run()
   globalFrame->Resize(globalFrame->GetDefaultSize());
   baseFrame->Resize(baseFrame->GetDefaultSize());
 
-  fMainWindow->SetWindowName("Event Display ver 0.2");
+  fMainWindow->SetWindowName("J-PET Event Display ver 0.2");
   fMainWindow->MapSubwindows();
   fMainWindow->Resize(fMainWindow->GetDefaultSize());
   fMainWindow->MapWindow();

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -123,7 +123,6 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
       AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame,
                         kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
 
-  // AddButton(frame1_1_2, "Read Geometry", "handleMenu(=0)");
   AddButton(frame1_1_2, "Read Data", "handleMenu(=1)");
 
   TGCheckButton *markersCheck =
@@ -309,21 +308,6 @@ void EventDisplay::handleMenu(Int_t id)
 {
   switch (id)
   {
-  /*case E_OpenGeometry:
-  {
-    TString dir("");
-    fFileInfo->fFileTypes = filetypes;
-    fFileInfo->fIniDir = StrDup(dir);
-    new TGFileDialog(gClient->GetRoot(), fMainWindow.get(), kFDOpen,
-  fFileInfo.get());
-    if(fFileInfo->fFilename == 0)
-      return;
-    assert(visualizator);
-    //visualizator->loadGeometry(fFileInfo->fFilename);
-    //visualizator->drawOnlyGeometry();
-    showData();
-  }
-  break;*/
   case E_OpenData:
   {
     TString dir("");
@@ -387,12 +371,7 @@ void EventDisplay::setMaxProgressBar(Int_t maxEvent)
   fProgBar->SetRange(0.0f, Float_t(maxEvent));
 }
 
-void EventDisplay::startVirtualization()
-{
-  startVirtualizationLoop(10);
-  // std::thread t(&EventDisplay::startVirtualizationLoop, this, 1);
-  // t.join();
-}
+void EventDisplay::startVirtualization() { startVirtualizationLoop(10); }
 
 void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
 {

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -16,27 +16,27 @@
 #ifndef EVENTDISPLAY_H
 #define EVENTDISPLAY_H
 
-
 #include <memory>
 #include <string>
 
 #include <TRint.h>
 
-#include <TGLabel.h>
-#include <TGNumberEntry.h>
-#include <TGMenu.h>
-#include <TGToolBar.h>
-#include <TGFileDialog.h>
-#include <TGStatusBar.h>
-#include <TGProgressBar.h>
+#include <TGButton.h>
 #include <TGButtonGroup.h>
+#include <TGFileDialog.h>
+#include <TGLabel.h>
+#include <TGMenu.h>
+#include <TGNumberEntry.h>
+#include <TGProgressBar.h>
+#include <TGStatusBar.h>
 #include <TGTab.h>
+#include <TGToolBar.h>
 
-#include <TGraph.h>
 #include <TBox.h>
+#include <TCanvas.h>
+#include <TGraph.h>
 #include <TMarker.h>
 #include <TRootEmbeddedCanvas.h>
-#include <TCanvas.h>
 
 #include <RQ_OBJECT.h>
 
@@ -58,10 +58,11 @@ struct GUIControlls
   Int_t rootEntries;
 };
 
-enum EMessageTypes {
- M_FILE_OPEN,
- M_FILE_SAVE,
- M_FILE_EXIT
+enum EMessageTypes
+{
+  M_FILE_OPEN,
+  M_FILE_SAVE,
+  M_FILE_EXIT
 };
 
 class EventDisplay
@@ -74,9 +75,15 @@ public:
 #ifndef __CINT__
   void run();
   void drawSelectedStrips();
-  void setMaxProgressBar (Int_t maxEvent);
-  inline void updateProgressBar () {fProgBar->SetPosition(Float_t(fGUIControls->eventNo));}
-  inline void updateProgressBar (Int_t num) {fProgBar->SetPosition(Float_t(num));}
+  void setMaxProgressBar(Int_t maxEvent);
+  inline void updateProgressBar()
+  {
+    fProgBar->SetPosition(Float_t(fGUIControls->eventNo));
+  }
+  inline void updateProgressBar(Int_t num)
+  {
+    fProgBar->SetPosition(Float_t(num));
+  }
 
   enum HandleMenuAction
   {
@@ -86,24 +93,23 @@ public:
   };
 #endif
 
-  //signals
+  // signals
   void CloseWindow();
-  void handleMenu (Int_t id);
+  void handleMenu(Int_t id);
   void updateGUIControlls();
   void doNext();
   void doReset();
   void showData();
   void startVirtualization();
+  void checkBoxMarkersSignalFunction();
 
 private:
-  
-
 #ifndef __CINT__
   EventDisplay(const EventDisplay &) = delete;
   EventDisplay &operator=(const EventDisplay &) = delete;
 
   void CreateDisplayFrame(TGGroupFrame *parentFrame);
-  void CreateOptionsFrame(TGGroupFrame* parentFrame);
+  void CreateOptionsFrame(TGGroupFrame *parentFrame);
 
   void AddTab(std::unique_ptr<TGTab> &pTabViews,
               std::unique_ptr<TRootEmbeddedCanvas> &saveCanvasPtr,
@@ -115,12 +121,12 @@ private:
   TGGroupFrame *AddGroupFrame(TGCompositeFrame *parentFrame,
                               const char *frameName, Int_t width, Int_t height);
 
-  TGCompositeFrame *AddCompositeFrame(TGCompositeFrame *parentFrame,
-                                      Int_t width, Int_t height,
-                                      Int_t options = kHorizontalFrame, 
-                                      ULong_t hints = kLHintsExpandX | kLHintsExpandY,
-                                      Int_t padleft = 0, Int_t padright = 0,
-                                      Int_t padtop = 0, Int_t padbottom = 0);
+  TGCompositeFrame *
+  AddCompositeFrame(TGCompositeFrame *parentFrame, Int_t width, Int_t height,
+                    Int_t options = kHorizontalFrame,
+                    ULong_t hints = kLHintsExpandX | kLHintsExpandY,
+                    Int_t padleft = 0, Int_t padright = 0, Int_t padtop = 0,
+                    Int_t padbottom = 0);
 
   void AddMenuBar(TGCompositeFrame *parentFrame);
 
@@ -128,16 +134,19 @@ private:
 
   ULong_t fFrameBackgroundColor = 0;
 
-  std::unique_ptr<DataProcessor> dataProcessor = std::unique_ptr<DataProcessor>(new DataProcessor());
+  std::unique_ptr<DataProcessor> dataProcessor =
+      std::unique_ptr<DataProcessor>(new DataProcessor());
   std::unique_ptr<GeometryVisualizator> visualizator =
-      std::unique_ptr<GeometryVisualizator>(
-          new GeometryVisualizator(3, 5, std::vector<std::pair<int, double>>(
-                                          {std::pair<int, double>(48, 42.5),
-                                           std::pair<int, double>(48, 46.75),
-                                           std::pair<int, double>(96, 57.5)})));
+      std::unique_ptr<GeometryVisualizator>(new GeometryVisualizator(
+          3, 5, std::vector<std::pair<int, double>>(
+                    {std::pair<int, double>(48, 42.5),
+                     std::pair<int, double>(48, 46.75),
+                     std::pair<int, double>(96, 57.5)})));
 
-  std::unique_ptr<TRint> fApplication = std::unique_ptr<TRint>(new TRint("EventDisplay Gui", 0, 0));
-  std::unique_ptr<GUIControlls> fGUIControls = std::unique_ptr<GUIControlls>(new GUIControlls);
+  std::unique_ptr<TRint> fApplication =
+      std::unique_ptr<TRint>(new TRint("EventDisplay Gui", 0, 0));
+  std::unique_ptr<GUIControlls> fGUIControls =
+      std::unique_ptr<GUIControlls>(new GUIControlls);
   std::unique_ptr<TGTab> fDisplayTabView;
   std::unique_ptr<TGMainFrame> fMainWindow;
   std::unique_ptr<TGNumberEntry> fNumberEntryStep;
@@ -145,9 +154,9 @@ private:
   std::unique_ptr<TGHProgressBar> fProgBar;
   std::unique_ptr<TGLabel> fInputInfo;
 
-  std::unique_ptr<TGFileInfo> fFileInfo = std::unique_ptr<TGFileInfo>(new TGFileInfo);
+  std::unique_ptr<TGFileInfo> fFileInfo =
+      std::unique_ptr<TGFileInfo>(new TGFileInfo);
 #endif
-  
 };
 }
 #endif /*  !EVENTDISPLAY_H */

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -37,6 +37,7 @@
 #include <TGraph.h>
 #include <TMarker.h>
 #include <TRootEmbeddedCanvas.h>
+#include <TStyle.h>
 
 #include <RQ_OBJECT.h>
 

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -124,7 +124,7 @@ private:
   std::unique_ptr<DataProcessor> dataProcessor = std::unique_ptr<DataProcessor>(new DataProcessor());
   std::unique_ptr<GeometryVisualizator> visualizator =
       std::unique_ptr<GeometryVisualizator>(
-          new GeometryVisualizator(3, std::vector<std::pair<int, double>>(
+          new GeometryVisualizator(3, 500, std::vector<std::pair<int, double>>(
                                           {std::pair<int, double>(48, 42.5),
                                            std::pair<int, double>(48, 46.75),
                                            std::pair<int, double>(96, 57.5)})));

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -124,7 +124,7 @@ private:
   std::unique_ptr<DataProcessor> dataProcessor = std::unique_ptr<DataProcessor>(new DataProcessor());
   std::unique_ptr<GeometryVisualizator> visualizator =
       std::unique_ptr<GeometryVisualizator>(
-          new GeometryVisualizator(3, 500, std::vector<std::pair<int, double>>(
+          new GeometryVisualizator(3, 5, std::vector<std::pair<int, double>>(
                                           {std::pair<int, double>(48, 42.5),
                                            std::pair<int, double>(48, 46.75),
                                            std::pair<int, double>(96, 57.5)})));

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -122,7 +122,12 @@ private:
   ULong_t fFrameBackgroundColor = 0;
 
   std::unique_ptr<DataProcessor> dataProcessor = std::unique_ptr<DataProcessor>(new DataProcessor());
-  std::unique_ptr<GeometryVisualizator> visualizator = std::unique_ptr<GeometryVisualizator>(new GeometryVisualizator());
+  std::unique_ptr<GeometryVisualizator> visualizator =
+      std::unique_ptr<GeometryVisualizator>(
+          new GeometryVisualizator(3, std::vector<std::pair<int, double>>(
+                                          {std::pair<int, double>(48, 42.5),
+                                           std::pair<int, double>(48, 46.75),
+                                           std::pair<int, double>(96, 57.5)})));
 
   std::unique_ptr<TRint> fApplication = std::unique_ptr<TRint>(new TRint("EventDisplay Gui", 0, 0));
   std::unique_ptr<GUIControlls> fGUIControls = std::unique_ptr<GUIControlls>(new GUIControlls);

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -39,9 +39,10 @@
 
 #include <RQ_OBJECT.h>
 
+#ifndef __CINT__
 #include "GeometryVisualizator.h"
 #include "DataProcessor.h"
-
+#endif
 
 namespace jpet_event_display
 {
@@ -120,8 +121,8 @@ private:
 
   ULong_t fFrameBackgroundColor = 0;
 
-  std::unique_ptr<GeometryVisualizator> visualizator = std::unique_ptr<GeometryVisualizator>(new GeometryVisualizator());
   std::unique_ptr<DataProcessor> dataProcessor = std::unique_ptr<DataProcessor>(new DataProcessor());
+  std::unique_ptr<GeometryVisualizator> visualizator = std::unique_ptr<GeometryVisualizator>(new GeometryVisualizator());
 
   std::unique_ptr<TRint> fApplication = std::unique_ptr<TRint>(new TRint("EventDisplay Gui", 0, 0));
   std::unique_ptr<GUIControlls> fGUIControls = std::unique_ptr<GUIControlls>(new GUIControlls);

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -16,6 +16,7 @@
 #ifndef EVENTDISPLAY_H
 #define EVENTDISPLAY_H
 
+
 #include <memory>
 #include <string>
 
@@ -40,8 +41,11 @@
 #include <RQ_OBJECT.h>
 
 #ifndef __CINT__
-#include "GeometryVisualizator.h"
 #include "DataProcessor.h"
+#include "GeometryVisualizator.h"
+
+#include <chrono>
+#include <thread>
 #endif
 
 namespace jpet_event_display
@@ -89,7 +93,8 @@ public:
   void doNext();
   void doReset();
   void showData();
-  
+  void startVirtualization();
+
 private:
   
 
@@ -118,6 +123,8 @@ private:
                                       Int_t padtop = 0, Int_t padbottom = 0);
 
   void AddMenuBar(TGCompositeFrame *parentFrame);
+
+  void startVirtualizationLoop(const int waitTimeInMs = 1000);
 
   ULong_t fFrameBackgroundColor = 0;
 

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -70,7 +70,9 @@ class EventDisplay
 {
   RQ_OBJECT("EventDisplay")
 public:
-  EventDisplay();
+  EventDisplay(const std::string &paramGetterAnsiiPath, const int runNumber,
+               const int numberOfLayers, const int scintillatorLenght,
+               const std::vector< std::pair< int, double > > &layerStats);
   ~EventDisplay();
 
 #ifndef __CINT__
@@ -135,15 +137,8 @@ private:
 
   ULong_t fFrameBackgroundColor = 0;
 
-  std::unique_ptr< DataProcessor > dataProcessor =
-      std::unique_ptr< DataProcessor >(
-          new DataProcessor("large_barrel.json", 44));
-  std::unique_ptr< GeometryVisualizator > visualizator =
-      std::unique_ptr< GeometryVisualizator >(new GeometryVisualizator(
-          3, 50, std::vector< std::pair< int, double > >(
-                     {std::pair< int, double >(48, 42.5),
-                      std::pair< int, double >(48, 46.75),
-                      std::pair< int, double >(96, 57.5)})));
+  std::unique_ptr< DataProcessor > dataProcessor;
+  std::unique_ptr< GeometryVisualizator > visualizator;
 
   std::unique_ptr< TRint > fApplication =
       std::unique_ptr< TRint >(new TRint("EventDisplay Gui", 0, 0));

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -111,8 +111,8 @@ private:
   void CreateDisplayFrame(TGGroupFrame *parentFrame);
   void CreateOptionsFrame(TGGroupFrame *parentFrame);
 
-  void AddTab(std::unique_ptr<TGTab> &pTabViews,
-              std::unique_ptr<TRootEmbeddedCanvas> &saveCanvasPtr,
+  void AddTab(std::unique_ptr< TGTab > &pTabViews,
+              std::unique_ptr< TRootEmbeddedCanvas > &saveCanvasPtr,
               const char *tabName, const char *canvasName);
 
   void AddButton(TGCompositeFrame *parentFrame, const char *buttonText,
@@ -134,28 +134,28 @@ private:
 
   ULong_t fFrameBackgroundColor = 0;
 
-  std::unique_ptr<DataProcessor> dataProcessor =
-      std::unique_ptr<DataProcessor>(new DataProcessor());
-  std::unique_ptr<GeometryVisualizator> visualizator =
-      std::unique_ptr<GeometryVisualizator>(new GeometryVisualizator(
-          3, 5, std::vector<std::pair<int, double>>(
-                    {std::pair<int, double>(48, 42.5),
-                     std::pair<int, double>(48, 46.75),
-                     std::pair<int, double>(96, 57.5)})));
+  std::unique_ptr< DataProcessor > dataProcessor =
+      std::unique_ptr< DataProcessor >(new DataProcessor());
+  std::unique_ptr< GeometryVisualizator > visualizator =
+      std::unique_ptr< GeometryVisualizator >(new GeometryVisualizator(
+          3, 50, std::vector< std::pair< int, double > >(
+                     {std::pair< int, double >(48, 42.5),
+                      std::pair< int, double >(48, 46.75),
+                      std::pair< int, double >(96, 57.5)})));
 
-  std::unique_ptr<TRint> fApplication =
-      std::unique_ptr<TRint>(new TRint("EventDisplay Gui", 0, 0));
-  std::unique_ptr<GUIControlls> fGUIControls =
-      std::unique_ptr<GUIControlls>(new GUIControlls);
-  std::unique_ptr<TGTab> fDisplayTabView;
-  std::unique_ptr<TGMainFrame> fMainWindow;
-  std::unique_ptr<TGNumberEntry> fNumberEntryStep;
-  std::unique_ptr<TGNumberEntry> fNumberEntryEventNo;
-  std::unique_ptr<TGHProgressBar> fProgBar;
-  std::unique_ptr<TGLabel> fInputInfo;
+  std::unique_ptr< TRint > fApplication =
+      std::unique_ptr< TRint >(new TRint("EventDisplay Gui", 0, 0));
+  std::unique_ptr< GUIControlls > fGUIControls =
+      std::unique_ptr< GUIControlls >(new GUIControlls);
+  std::unique_ptr< TGTab > fDisplayTabView;
+  std::unique_ptr< TGMainFrame > fMainWindow;
+  std::unique_ptr< TGNumberEntry > fNumberEntryStep;
+  std::unique_ptr< TGNumberEntry > fNumberEntryEventNo;
+  std::unique_ptr< TGHProgressBar > fProgBar;
+  std::unique_ptr< TGLabel > fInputInfo;
 
-  std::unique_ptr<TGFileInfo> fFileInfo =
-      std::unique_ptr<TGFileInfo>(new TGFileInfo);
+  std::unique_ptr< TGFileInfo > fFileInfo =
+      std::unique_ptr< TGFileInfo >(new TGFileInfo);
 #endif
 };
 }

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -136,7 +136,8 @@ private:
   ULong_t fFrameBackgroundColor = 0;
 
   std::unique_ptr< DataProcessor > dataProcessor =
-      std::unique_ptr< DataProcessor >(new DataProcessor());
+      std::unique_ptr< DataProcessor >(
+          new DataProcessor("large_barrel.json", 44));
   std::unique_ptr< GeometryVisualizator > visualizator =
       std::unique_ptr< GeometryVisualizator >(new GeometryVisualizator(
           3, 50, std::vector< std::pair< int, double > >(

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -238,7 +238,7 @@ void GeometryVisualizator::setVisibility2d(
 
 void GeometryVisualizator::drawStrips(const ScintillatorsInLayers &selection)
 {
-  // setAllStripsUnvisible();
+  setAllStripsUnvisible();
   setAllStripsUnvisible2d();
   if (selection.empty())
     return;
@@ -268,7 +268,7 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
       strip = *stripIter;
       nodeStrip = nodeLayer->GetDaughter(strip - 1);
       assert(nodeStrip);
-      nodeStrip->SetVisibility(kTRUE);
+      nodeStrip->GetVolume()->SetLineColor(kRed);
     }
   }
 }
@@ -386,7 +386,7 @@ void GeometryVisualizator::setAllStripsUnvisible()
     for (int j = 0; j < fNumberOfStrips; j++)
     {
       TGeoNode *stripNode = node->GetDaughter(j);
-      stripNode->SetVisibility(kFALSE);
+      stripNode->GetVolume()->SetLineColor(kBlack);
     }
   }
 }
@@ -564,7 +564,6 @@ void GeometryVisualizator::createGeometry(
     layers.push_back(layer);
   }
 
-  TGeoVolume *scin = gGeoManager->MakeTube("scin", medium, 0, 0.7, 50);
   TGeoVolume *vol = 0;
   char nameOfLayer[100];
   int i = 0;
@@ -581,6 +580,8 @@ void GeometryVisualizator::createGeometry(
     currentFi = startFi[i];
     for (int j = 0; j < layerStats[i].first; j++)
     {
+      TGeoVolume *scin = gGeoManager->MakeTube("scin", medium, 0, 0.7, 50);
+      scin->SetLineWidth(5);
       vol->AddNode(
           scin, j,
           new TGeoTranslation(
@@ -594,5 +595,6 @@ void GeometryVisualizator::createGeometry(
   }
   fGeoManager->CloseGeometry();
   fGeoManager->SetVisLevel(0);
+  fGeoManager->Export("tt.root");
 }
 }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -173,10 +173,10 @@ void GeometryVisualizator::setVisibility2d(
           strip < numberOfScintilatorsInLayer[layer] && strip >= 0)
       {
         allScintilatorsCanv[layer][strip].image->SetFillColor(2);
-        double scaledScinLenght =
-            allScintilatorsCanv[layer][strip].image->GetX2() -
-            allScintilatorsCanv[layer][strip].image->GetX1();
-        double scale = scaledScinLenght / fScinLenghtWithoutScale;
+        //double scaledScinLenght =
+        //    allScintilatorsCanv[layer][strip].image->GetX2() -
+        //    allScintilatorsCanv[layer][strip].image->GetX1();
+        //double scale = scaledScinLenght / fScinLenghtWithoutScale;
         double centerX = allScintilatorsCanv[layer][strip].image->GetX1() +
                          ((allScintilatorsCanv[layer][strip].image->GetX2() -
                            allScintilatorsCanv[layer][strip].image->GetX1()) /
@@ -238,8 +238,6 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
 void GeometryVisualizator::drawMarkers(const HitPositions &pos)
 {
   fCanvasTopView->cd();
-  int vectorLineSize = fLineOnTopView.size();
-  int vectorMarkerSize = fMarkerOnTopView.size();
   if(!fSaveMarkersAndLinesBetweenEvents)
   {
     for(TPolyLine * line : fLineOnTopView)
@@ -257,17 +255,17 @@ void GeometryVisualizator::drawMarkers(const HitPositions &pos)
   }
   fLineOnTopView.push_back(new TPolyLine());
   fMarkerOnTopView.push_back(new TPolyMarker());
-  for (Int_t jc = 0; jc < pos.size(); jc++)
+  for (unsigned int i = 0; i < pos.size(); i++)
   {
     fLineOnTopView.back()->SetLineWidth(2);
     fLineOnTopView.back()->SetLineColor(kRed);
     fLineOnTopView.back()->SetLineStyle(4);
-    fLineOnTopView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X());
+    fLineOnTopView.back()->SetNextPoint(pos[i].Y(), pos[i].X());
 
     fMarkerOnTopView.back()->SetMarkerSize(2);
     fMarkerOnTopView.back()->SetMarkerColor(kBlack);
     fMarkerOnTopView.back()->SetMarkerStyle(2);
-    fMarkerOnTopView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X());
+    fMarkerOnTopView.back()->SetNextPoint(pos[i].Y(), pos[i].X());
   }
   fLineOnTopView.back()->Draw();
   fMarkerOnTopView.back()->Draw();
@@ -276,8 +274,6 @@ void GeometryVisualizator::drawMarkers(const HitPositions &pos)
 void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 {
   fCanvas3d->cd();
-  int vectorLineSize = fLineOn3dView.size();
-  int vectorMarkerSize = fMarkerOn3dView.size();
   if(!fSaveMarkersAndLinesBetweenEvents)
   {
     for(TPolyLine3D * line : fLineOn3dView)
@@ -295,17 +291,17 @@ void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
   }
   fLineOn3dView.push_back(new TPolyLine3D());
   fMarkerOn3dView.push_back(new TPolyMarker3D());
-  for (Int_t jc = 0; jc < pos.size(); jc++)
+  for (unsigned int i = 0; i < pos.size(); i++)
   {
     fLineOn3dView.back()->SetLineWidth(2);
     fLineOn3dView.back()->SetLineColor(kRed);
     fLineOn3dView.back()->SetLineStyle(4);
-    fLineOn3dView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+    fLineOn3dView.back()->SetNextPoint(pos[i].Y(), pos[i].X(), pos[i].Z());
 
     fMarkerOn3dView.back()->SetMarkerSize(2);
     fMarkerOn3dView.back()->SetMarkerColor(kBlack);
     fMarkerOn3dView.back()->SetMarkerStyle(2);
-    fMarkerOn3dView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+    fMarkerOn3dView.back()->SetNextPoint(pos[i].Y(), pos[i].X(), pos[i].Z());
   }
   fLineOn3dView.back()->Draw();
   fMarkerOn3dView.back()->Draw();

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -27,7 +27,23 @@ namespace jpet_event_display
 
 GeometryVisualizator::GeometryVisualizator() { }
 
-  GeometryVisualizator::~GeometryVisualizator() { }
+GeometryVisualizator::~GeometryVisualizator() { }
+
+void GeometryVisualizator::drawData()
+{
+  switch(ProcessedData::getInstance().getCurrentFileType())
+  {
+    case FileTypes::fTimeWindow:
+      setVisibility(ProcessedData::getInstance().getActivedScintilators());
+      break;
+    case FileTypes::fRawSignal:
+      setVisibility(ProcessedData::getInstance().getActivedScintilators());
+      drawDiagram(ProcessedData::getInstance().getDiagramData());
+      break;
+    default:
+      break;
+  }
+}
 
   void GeometryVisualizator::loadGeometry(const std::string& geomFile)
   {

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -39,9 +39,11 @@ void GeometryVisualizator::drawData()
 {
   drawStrips(ProcessedData::getInstance().getActivedScintilators());
   drawDiagram(ProcessedData::getInstance().getDiagramData());
+  drawLineBetweenActivedScins(ProcessedData::getInstance().getHits());
 
   updateCanvas(fCanvas3d);
   updateCanvas(fCanvas2d);
+  updateCanvas(fCanvas2d2);
   updateCanvas(fCanvasDiagrams);
 }
 
@@ -56,11 +58,14 @@ void GeometryVisualizator::showGeometry()
 {
   assert(fRootCanvas3d);
   assert(fRootCanvas2d);
+  assert(fRootCanvas2d2);
   assert(fRootCanvasDiagrams);
   if (!fCanvas3d)
     fCanvas3d = std::unique_ptr<TCanvas>(fRootCanvas3d->GetCanvas());
   if(!fCanvas2d)
     fCanvas2d = std::unique_ptr<TCanvas>(fRootCanvas2d->GetCanvas());
+  if (!fCanvas2d2)
+    fCanvas2d2 = std::unique_ptr<TCanvas>(fRootCanvas2d2->GetCanvas());
   if(!fCanvasDiagrams)
     fCanvasDiagrams =
         std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
@@ -69,6 +74,7 @@ void GeometryVisualizator::showGeometry()
   setAllStripsUnvisible();
   //setAllStripsUnvisible2d();
 
+  draw2dGeometry2();
 
   fCanvas3d->cd();
   assert(fGeoManager);
@@ -224,6 +230,57 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
       nodeStrip->SetVisibility(kTRUE);
     }
   }
+}
+
+void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
+{
+  fCanvas3d->cd();
+  std::cout << "pos size: " << pos.size() << "\n";
+  TPolyLine3D *line = new TPolyLine3D();
+  line->SetLineWidth(2);
+  line->SetLineColor(kRed);
+  line->SetLineStyle(4);
+  TPolyMarker3D *pm3d1 = new TPolyMarker3D();
+  pm3d1->SetMarkerSize(2);
+  pm3d1->SetMarkerColor(kBlack);
+  pm3d1->SetMarkerStyle(2);
+  for (Int_t jc = 0; jc < pos.size(); jc++)
+  {
+    line->SetPoint(jc, pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+    pm3d1->SetPoint(jc, pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+  }
+  line->Draw();
+  pm3d1->Draw();
+}
+
+void GeometryVisualizator::draw2dGeometry2()
+{
+  fCanvas2d2->cd();
+  const double firstLayerRadius = 0.2956;
+  const double secondLayerRadius = 0.3252;
+  const double thirdLayerRadius = 0.4;
+  const double middle = 0.5;
+  TEllipse *thirdLayerCircle =
+      new TEllipse(middle, middle, thirdLayerRadius, thirdLayerRadius);
+  thirdLayerCircle->Draw();
+  TEllipse *secondLayerCircle =
+      new TEllipse(middle, middle, secondLayerRadius, secondLayerRadius);
+  secondLayerCircle->Draw();
+  TEllipse *firstLayerCircle =
+      new TEllipse(middle, middle, firstLayerRadius, firstLayerRadius);
+  firstLayerCircle->Draw();
+
+  TEllipse *testScin =
+      new TEllipse(middle, middle, firstLayerRadius, firstLayerRadius, 0, 360/48);
+  testScin->Draw();
+
+  TGaxis *axisX = new TGaxis(0.1, 0.5, 0.9, 0.5, -57.5, 57.5, 50510, "");
+  axisX->SetName("axisX");
+  axisX->Draw();
+
+  TGaxis *axisY = new TGaxis(0.5, 0.1, 0.5, 0.9, -57.5, 57.5, 50510, "");
+  axisY->SetName("axisY");
+  axisY->Draw();
 }
 
 void GeometryVisualizator::setAllStripsUnvisible()

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -529,21 +529,6 @@ float GeometryVisualizator::changeSignalNumber(int signalNumber)
                                                   // threshold is on top
 }
 
-void GeometryVisualizator::reverseYAxis(TGraph *g)
-{
-  // Remove the current axis
-  g->GetYaxis()->SetLabelOffset(999);
-  g->GetYaxis()->SetTickLength(0);
-
-  gPad->Update();
-  TGaxis *newaxis =
-      new TGaxis(gPad->GetUxmin(), gPad->GetUymax(), gPad->GetUxmin() - 0.001,
-                 gPad->GetUymin(), g->GetYaxis()->GetXmin(),
-                 g->GetYaxis()->GetXmax(), 510, "+");
-  newaxis->SetLabelOffset(-0.03);
-  newaxis->Draw();
-}
-
 void GeometryVisualizator::createGeometry(
     const int numberOfLayers, const int kLength,
     const std::vector< std::pair< int, double > > &layerStats)

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -351,7 +351,8 @@ void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 
 void GeometryVisualizator::draw2dGeometry2()
 {
-  const double canvasRange = 100;
+  const double canvasRange = 60;
+  const double axisPos = 59;
   fCanvasTopView->cd();
   fCanvasTopView->Range(-canvasRange, -canvasRange, canvasRange, canvasRange);
   TEllipse *thirdLayerCircle = new TEllipse(0, 0, 57.5, 57.5);
@@ -361,12 +362,16 @@ void GeometryVisualizator::draw2dGeometry2()
   TEllipse *firstLayerCircle = new TEllipse(0, 0, 42.5, 42.5);
   firstLayerCircle->Draw();
 
-  TGaxis *axisX = new TGaxis(-57.5, 0, 57.5, 0, -57.5, 57.5, 50510, "");
+  TGaxis *axisX =
+      new TGaxis(-57.5, axisPos, 57.5, axisPos, -57.5, 57.5, 50510, "");
   axisX->SetName("axisX");
+  axisX->SetLabelSize(0.02);
   axisX->Draw();
 
-  TGaxis *axisY = new TGaxis(0, -57.5, 0, 57.5, -57.5, 57.5, 50510, "");
+  TGaxis *axisY =
+      new TGaxis(axisPos, -57.5, axisPos, 57.5, -57.5, 57.5, 50510, "");
   axisY->SetName("axisY");
+  axisY->SetLabelSize(0.02);
   axisY->Draw();
 }
 
@@ -386,7 +391,7 @@ void GeometryVisualizator::setAllStripsUnvisible()
     for (int j = 0; j < fNumberOfStrips; j++)
     {
       TGeoNode *stripNode = node->GetDaughter(j);
-      stripNode->GetVolume()->SetLineColor(kBlack);
+      stripNode->GetVolume()->SetLineColor(layersColors[i]);
     }
   }
 }
@@ -419,18 +424,18 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     std::vector< float > leadingY;
     std::vector< float > trailingX;
     std::vector< float > trailingY;
-    double changePsToNs = 0.001;
+    const float changePsToNs = 0.001;
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
       if (std::get< 3 >(*it) == JPetSigCh::Leading)
       {
-        leadingX.push_back(static_cast< double >(std::get< 2 >(*it)) *
+        leadingX.push_back(static_cast< float >(std::get< 2 >(*it)) *
                            changePsToNs);
         leadingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
       else
       {
-        trailingX.push_back(static_cast< double >(std::get< 2 >(*it)) *
+        trailingX.push_back(static_cast< float >(std::get< 2 >(*it)) *
                             changePsToNs);
         trailingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
@@ -467,10 +472,11 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     mg->GetYaxis()->SetLabelOffset(999);
     mg->GetYaxis()->SetTickLength(0);
     mg->GetYaxis()->SetRangeUser(0, 5);
-    mg->GetXaxis()->SetLimits(mg->GetXaxis()->GetXmin(),
-                              mg->GetXaxis()->GetXmax());
+    mg->GetXaxis()->SetLimits(0, 50);
+    // mg->GetXaxis()->SetLimits(mg->GetXaxis()->GetXmin() - 10 * 1000,
+    //                          mg->GetXaxis()->GetXmin() + 20 * 1000);
     mg->GetXaxis()->SetNdivisions(504, kFALSE);
-    mg->GetXaxis()->SetTitle("Time");
+    mg->GetXaxis()->SetTitle("Time (ns)");
     mg->GetYaxis()->SetTitle("Threshold Number");
 
     for (int k = 0; k < 4; k++)
@@ -483,8 +489,8 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
   }
 }
 
-double
-GeometryVisualizator::changeSignalNumber(int signalNumber) // change this...
+float GeometryVisualizator::changeSignalNumber(
+    int signalNumber) // change this...
 {
   // std::cout << "signalNumber: " << signalNumber << "\n";
   if (signalNumber == 4)
@@ -566,12 +572,14 @@ void GeometryVisualizator::createGeometry(
     vol = new TGeoVolume(nameOfLayer, layer, medium);
     assert(vol);
     vol->SetVisibility(kTRUE);
-    vol->SetLineColor(kBlack);
     currentFi = startFi[i];
     for (int j = 0; j < layerStats[i].first; j++)
     {
       TGeoVolume *scin = gGeoManager->MakeTube("scin", medium, 0, 0.7, 50);
       scin->SetLineWidth(5);
+      // scin->SetLineColor(layersColors[i]);
+
+      scin->SetLineColorAlpha(layersColors[i], 0.3);
       vol->AddNode(
           scin, j,
           new TGeoTranslation(

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -27,7 +27,7 @@ namespace jpet_event_display
 
 GeometryVisualizator::GeometryVisualizator(
     const int numberOfLayers, const int kLength,
-    const std::vector<std::pair<int, double>> &layerStats)
+    const std::vector< std::pair< int, double > > &layerStats)
     : fScinLenghtWithoutScale(kLength)
 {
   createGeometry(numberOfLayers, kLength, layerStats);
@@ -41,7 +41,6 @@ void GeometryVisualizator::drawData()
   drawDiagram(ProcessedData::getInstance().getDiagramData());
   drawLineBetweenActivedScins(ProcessedData::getInstance().getHits());
   drawMarkers(ProcessedData::getInstance().getHits());
-  //std::cout << "state: " << fSaveMarkersAndLinesBetweenEvents << "\n";
 
   updateCanvas(fCanvas3d);
   updateCanvas(fCanvas2d);
@@ -49,7 +48,7 @@ void GeometryVisualizator::drawData()
   updateCanvas(fCanvasDiagrams);
 }
 
-void GeometryVisualizator::updateCanvas(std::unique_ptr<TCanvas> &canvas)
+void GeometryVisualizator::updateCanvas(std::unique_ptr< TCanvas > &canvas)
 {
   canvas->Draw();
   canvas->Update();
@@ -63,14 +62,15 @@ void GeometryVisualizator::showGeometry()
   assert(fRootCanvasTopView);
   assert(fRootCanvasDiagrams);
   if (!fCanvas3d)
-    fCanvas3d = std::unique_ptr<TCanvas>(fRootCanvas3d->GetCanvas());
+    fCanvas3d = std::unique_ptr< TCanvas >(fRootCanvas3d->GetCanvas());
   if (!fCanvas2d)
-    fCanvas2d = std::unique_ptr<TCanvas>(fRootCanvas2d->GetCanvas());
+    fCanvas2d = std::unique_ptr< TCanvas >(fRootCanvas2d->GetCanvas());
   if (!fCanvasTopView)
-    fCanvasTopView = std::unique_ptr<TCanvas>(fRootCanvasTopView->GetCanvas());
+    fCanvasTopView =
+        std::unique_ptr< TCanvas >(fRootCanvasTopView->GetCanvas());
   if (!fCanvasDiagrams)
     fCanvasDiagrams =
-        std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
+        std::unique_ptr< TCanvas >(fRootCanvasDiagrams->GetCanvas());
 
   draw2dGeometry();
   setAllStripsUnvisible();
@@ -164,7 +164,7 @@ void GeometryVisualizator::setVisibility2d(
   for (auto iter = selection.begin(); iter != selection.end(); ++iter)
   {
     int layer = iter->first - 1; // table start form 0, layers from 1
-    const std::vector<size_t> &strips = iter->second;
+    const std::vector< size_t > &strips = iter->second;
     for (auto stripIter = strips.begin(); stripIter != strips.end();
          ++stripIter)
     {
@@ -173,10 +173,10 @@ void GeometryVisualizator::setVisibility2d(
           strip < numberOfScintilatorsInLayer[layer] && strip >= 0)
       {
         allScintilatorsCanv[layer][strip].image->SetFillColor(2);
-        //double scaledScinLenght =
+        // double scaledScinLenght =
         //    allScintilatorsCanv[layer][strip].image->GetX2() -
         //    allScintilatorsCanv[layer][strip].image->GetX1();
-        //double scale = scaledScinLenght / fScinLenghtWithoutScale;
+        // double scale = scaledScinLenght / fScinLenghtWithoutScale;
         double centerX = allScintilatorsCanv[layer][strip].image->GetX1() +
                          ((allScintilatorsCanv[layer][strip].image->GetX2() -
                            allScintilatorsCanv[layer][strip].image->GetX1()) /
@@ -185,7 +185,6 @@ void GeometryVisualizator::setVisibility2d(
                          ((allScintilatorsCanv[layer][strip].image->GetY2() -
                            allScintilatorsCanv[layer][strip].image->GetY1()) /
                           2);
-        //std::cout << "marker center: " << centerX << "  " << centerY << "\n";
         allScintilatorsCanv[layer][strip].event =
             new TMarker(centerX, centerY, 3);
         allScintilatorsCanv[layer][strip].event->SetMarkerColor(2);
@@ -220,7 +219,7 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
   for (auto iter = selection.begin(); iter != selection.end(); ++iter)
   {
     layer = iter->first;
-    const std::vector<size_t> &strips = iter->second;
+    const std::vector< size_t > &strips = iter->second;
     nodeLayer = topNode->GetDaughter(layer - 1);
     assert(nodeLayer);
 
@@ -238,15 +237,15 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
 void GeometryVisualizator::drawMarkers(const HitPositions &pos)
 {
   fCanvasTopView->cd();
-  if(!fSaveMarkersAndLinesBetweenEvents)
+  if (!fSaveMarkersAndLinesBetweenEvents)
   {
-    for(TPolyLine * line : fLineOnTopView)
+    for (TPolyLine *line : fLineOnTopView)
     {
       fCanvasTopView->GetListOfPrimitives()->Remove(line);
       delete line;
     }
     fLineOnTopView.clear();
-    for(TPolyMarker * marker : fMarkerOnTopView)
+    for (TPolyMarker *marker : fMarkerOnTopView)
     {
       fCanvasTopView->GetListOfPrimitives()->Remove(marker);
       delete marker;
@@ -274,15 +273,15 @@ void GeometryVisualizator::drawMarkers(const HitPositions &pos)
 void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 {
   fCanvas3d->cd();
-  if(!fSaveMarkersAndLinesBetweenEvents)
+  if (!fSaveMarkersAndLinesBetweenEvents)
   {
-    for(TPolyLine3D * line : fLineOn3dView)
+    for (TPolyLine3D *line : fLineOn3dView)
     {
       fCanvas3d->GetListOfPrimitives()->Remove(line);
       delete line;
     }
     fLineOn3dView.clear();
-    for(TPolyMarker3D * marker : fMarkerOn3dView)
+    for (TPolyMarker3D *marker : fMarkerOn3dView)
     {
       fCanvas3d->GetListOfPrimitives()->Remove(marker);
       delete marker;
@@ -332,7 +331,7 @@ void GeometryVisualizator::setAllStripsUnvisible()
 {
   assert(fGeoManager);
   TGeoNodeMatrix *topNode =
-      static_cast<TGeoNodeMatrix *>(fGeoManager->GetTopNode());
+      static_cast< TGeoNodeMatrix * >(fGeoManager->GetTopNode());
   assert(topNode);
   int fNumberOfLayers = topNode->GetNdaughters();
   TGeoNode *node = 0;
@@ -358,9 +357,8 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
   }
   if (fCanvasDiagrams == 0)
     fCanvasDiagrams =
-        std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
+        std::unique_ptr< TCanvas >(fRootCanvasDiagrams->GetCanvas());
   int vectorSize = diagramData.size();
-  //std::cout << "vector size: " << vectorSize << "\n";
   fCanvasDiagrams->cd();
   if (vectorSize != fLastDiagramVectorSize)
   {
@@ -377,16 +375,14 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     int i = 0;
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
-      y[i] = static_cast<double>(std::get<0>(*it));
-      // y[i] = static_cast<double>(it->second.first);
-      x[i] = static_cast<double>(std::get<2>(*it));
-      // std::cout << "x: " << x[i] << " y: " << y[i] << "\n";
+      y[i] = static_cast< double >(std::get< 0 >(*it));
+      x[i] = static_cast< double >(std::get< 2 >(*it));
       i++;
     }
     TGraph *gr = new TGraph(n, x, y);
     gr->GetXaxis()->SetTitle("Time");
     gr->GetYaxis()->SetTitle("Threshold Number");
-    gr->Draw("AP*"); // ACP*
+    gr->Draw("AP*");
     for (int k = 0; k < 4; k++)
     {
       TLine *line = new TLine(gr->GetXaxis()->GetXmin(), k + 1,
@@ -399,7 +395,7 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
 
 void GeometryVisualizator::createGeometry(
     const int numberOfLayers, const int kLength,
-    const std::vector<std::pair<int, double>> &layerStats)
+    const std::vector< std::pair< int, double > > &layerStats)
 {
   const double kXWorld = kLength + 100;
   const double kYWorld = kLength + 100;
@@ -409,7 +405,7 @@ void GeometryVisualizator::createGeometry(
   gSystem->Load("libGeom");
 
   fGeoManager =
-      std::unique_ptr<TGeoManager>(new TGeoManager("mgr", "PET detector"));
+      std::unique_ptr< TGeoManager >(new TGeoManager("mgr", "PET detector"));
 
   TGeoMaterial *matVacuum = new TGeoMaterial("Vacuum", 0, 0, 0);
   assert(matVacuum);
@@ -428,7 +424,7 @@ void GeometryVisualizator::createGeometry(
   TGeoRotation *rotation = new TGeoRotation();
   rotation->SetAngles(0., 0., 0.);
 
-  std::vector<TGeoTube *> layers;
+  std::vector< TGeoTube * > layers;
 
   for (int i = 0; i < numberOfLayers; i++)
   {
@@ -456,7 +452,7 @@ void GeometryVisualizator::createGeometry(
     assert(array);
     TGeoNode *strip = 0;
     TIter iter(array);
-    while ((strip = static_cast<TGeoNode *>(iter.Next())) != 0)
+    while ((strip = static_cast< TGeoNode * >(iter.Next())) != 0)
     {
       strip->GetVolume()->SetLineColor(kRed);
       strip->SetVisibility(kTRUE);

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -181,7 +181,7 @@ void GeometryVisualizator::setMarker2d(const HitPositions &pos,
     fUnRolledViewMarker.clear();
   }
 
-  static const double centerOfScintillator = 25;
+  static const double kCenterOfScintillator = 25; // TODO calculate lenght
   int i = 0;
   for (auto iter = selection.begin(); iter != selection.end(); ++iter)
   {
@@ -198,14 +198,14 @@ void GeometryVisualizator::setMarker2d(const HitPositions &pos,
             fUnRolledViewScintillators[layer][strip]->GetX2() -
             fUnRolledViewScintillators[layer][strip]->GetX1();
         double drawedScintillatorCenter = drawedScintillatorLength / 2;
-        double z = pos[i].Z() < centerOfScintillator &&
-                           pos[i].Z() > -centerOfScintillator
+        double z = pos[i].Z() < kCenterOfScintillator &&
+                           pos[i].Z() > -kCenterOfScintillator
                        ? pos[i].Z()
-                       : pos[i].Z() < centerOfScintillator
-                             ? -centerOfScintillator
-                             : centerOfScintillator;
+                       : pos[i].Z() < kCenterOfScintillator
+                             ? -kCenterOfScintillator
+                             : kCenterOfScintillator;
         double hittedXPos =
-            (drawedScintillatorCenter * z) / centerOfScintillator;
+            (drawedScintillatorCenter * z) / kCenterOfScintillator;
         double centerX = fUnRolledViewScintillators[layer][strip]->GetX1() +
                          ((fUnRolledViewScintillators[layer][strip]->GetX2() -
                            fUnRolledViewScintillators[layer][strip]->GetX1()) /
@@ -215,7 +215,7 @@ void GeometryVisualizator::setMarker2d(const HitPositions &pos,
                            fUnRolledViewScintillators[layer][strip]->GetY1()) /
                           2);
         TMarker *marker = new TMarker(centerX + hittedXPos, centerY, 3);
-        marker->SetMarkerColor(2);
+        marker->SetMarkerColor(kRed);
         marker->SetMarkerSize(3);
         marker->Draw();
         fUnRolledViewMarker.push_back(marker);
@@ -240,7 +240,7 @@ void GeometryVisualizator::setVisibility2d(
       if (layer < fUnRolledViewScintillators.size() &&
           strip < fUnRolledViewScintillators[layer].size())
       {
-        fUnRolledViewScintillators[layer][strip]->SetFillColor(2);
+        fUnRolledViewScintillators[layer][strip]->SetFillColor(kRed);
       }
     }
   }
@@ -272,7 +272,6 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
     {
       std::cout << "/* Bad layer number in setVisibility, returning...*/"
                 << "\n";
-      // Error("Bad layer number in setVisibility, returning...");
       return;
     }
     const std::vector< size_t > &strips = iter->second;
@@ -287,7 +286,6 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
       {
         std::cout << "/* Bad strip number in setVisibility, returning...*/"
                   << "\n";
-        // Error("Bad strip number in setVisibility, returning...");
         return;
       }
       nodeStrip = nodeLayer->GetDaughter(strip - 1);
@@ -353,12 +351,18 @@ void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
   }
   fLineOn3dView.push_back(new TPolyLine3D());
   fMarkerOn3dView.push_back(new TPolyMarker3D());
+  static const double kScintillatorLenghtFromCenter =
+      25; // TODO calculate lenght
   for (unsigned int i = 0; i < pos.size(); i++)
   {
     double x = pos[i].X();
     double y = pos[i].Y();
-    double z = pos[i].Z() < 25 && pos[i].Z() > -25 ? pos[i].Z()
-                                                   : pos[i].Z() < 25 ? -25 : 25;
+    double z = pos[i].Z() < kScintillatorLenghtFromCenter &&
+                       pos[i].Z() > -kScintillatorLenghtFromCenter
+                   ? pos[i].Z()
+                   : pos[i].Z() < kScintillatorLenghtFromCenter
+                         ? -kScintillatorLenghtFromCenter
+                         : kScintillatorLenghtFromCenter;
     fLineOn3dView.back()->SetLineWidth(2);
     fLineOn3dView.back()->SetLineColor(kRed);
     fLineOn3dView.back()->SetLineStyle(4);
@@ -379,21 +383,29 @@ void GeometryVisualizator::draw2dGeometry2()
   const double axisPos = 59;
   fCanvasTopView->cd();
   fCanvasTopView->Range(-canvasRange, -canvasRange, canvasRange, canvasRange);
-  TEllipse *thirdLayerCircle = new TEllipse(0, 0, 57.5, 57.5);
+  const double thirdLayerRadius = 57.5;
+  const double secondLayerRadius = 46.75;
+  const double firstLayerRadius = 42.5;
+  TEllipse *thirdLayerCircle =
+      new TEllipse(0, 0, thirdLayerRadius, thirdLayerRadius);
   thirdLayerCircle->Draw();
-  TEllipse *secondLayerCircle = new TEllipse(0, 0, 46.75, 46.75);
+  TEllipse *secondLayerCircle =
+      new TEllipse(0, 0, secondLayerRadius, secondLayerRadius);
   secondLayerCircle->Draw();
-  TEllipse *firstLayerCircle = new TEllipse(0, 0, 42.5, 42.5);
+  TEllipse *firstLayerCircle =
+      new TEllipse(0, 0, firstLayerRadius, firstLayerRadius);
   firstLayerCircle->Draw();
 
   TGaxis *axisX =
-      new TGaxis(-57.5, axisPos, 57.5, axisPos, -57.5, 57.5, 50510, "");
+      new TGaxis(-thirdLayerRadius, axisPos, thirdLayerRadius, axisPos,
+                 -thirdLayerRadius, thirdLayerRadius, 50510, "");
   axisX->SetName("axisX");
   axisX->SetLabelSize(0.02);
   axisX->Draw();
 
   TGaxis *axisY =
-      new TGaxis(axisPos, -57.5, axisPos, 57.5, -57.5, 57.5, 50510, "");
+      new TGaxis(axisPos, -thirdLayerRadius, axisPos, thirdLayerRadius,
+                 -thirdLayerRadius, thirdLayerRadius, 50510, "");
   axisY->SetName("axisY");
   axisY->SetLabelSize(0.02);
   axisY->Draw();

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -26,10 +26,10 @@ namespace jpet_event_display
 {
 
 GeometryVisualizator::GeometryVisualizator(
-    const int numberOfLayers,
+    const int numberOfLayers, const int kLength,
     const std::vector<std::pair<int, double>> &layerStats)
 {
-  createGeometry(numberOfLayers, layerStats);
+  createGeometry(numberOfLayers, kLength, layerStats);
 }
 
 GeometryVisualizator::~GeometryVisualizator() {}
@@ -76,7 +76,7 @@ void GeometryVisualizator::showGeometry()
   assert(gPad);
   TView *view = gPad->GetView();
   assert(view);
-  view->ZoomView(0, 2);
+  view->ZoomView(gPad, 1.75);
   view->SetView(0, 90, 0, irep);
   if(irep == -1)
     WARNING("Error in min-max scope setting view to 3d canvas");
@@ -277,14 +277,13 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
 }
 
 void GeometryVisualizator::createGeometry(
-    const int numberOfLayers,
+    const int numberOfLayers, const int kLength,
     const std::vector<std::pair<int, double>> &layerStats)
 {
-  const double kXWorld = 500;
-  const double kYWorld = 500;
-  const double kZWorld = 500;
+  const double kXWorld = kLength + 100;
+  const double kYWorld = kLength + 100;
+  const double kZWorld = kLength + 100;
 
-  const double kLength = 70;
   const double kLayerThickness = 0.9;
   gSystem->Load("libGeom");
 
@@ -314,7 +313,7 @@ void GeometryVisualizator::createGeometry(
   {
     TGeoTube *layer =
         new TGeoTube(layerStats[i].second,
-                     layerStats[i].second + kLayerThickness, kLength / 2.);
+                     layerStats[i].second + kLayerThickness, kLength);
     assert(layer);
     layers.push_back(layer);
   }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -181,7 +181,7 @@ void GeometryVisualizator::setMarker2d(const HitPositions &pos,
     fUnRolledViewMarker.clear();
   }
 
-  static const double kCenterOfScintillator = 25; // TODO calculate lenght
+  static const double kCenterOfScintillator = fScinLenghtWithoutScale / 2;
   int i = 0;
   for (auto iter = selection.begin(); iter != selection.end(); ++iter)
   {
@@ -351,8 +351,7 @@ void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
   }
   fLineOn3dView.push_back(new TPolyLine3D());
   fMarkerOn3dView.push_back(new TPolyMarker3D());
-  static const double kScintillatorLenghtFromCenter =
-      25; // TODO calculate lenght
+  static const double kScintillatorLenghtFromCenter = fScinLenghtWithoutScale;
   for (unsigned int i = 0; i < pos.size(); i++)
   {
     double x = pos[i].X();

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -41,9 +41,11 @@ void GeometryVisualizator::drawData()
   drawDiagram(ProcessedData::getInstance().getDiagramData());
   drawLineBetweenActivedScins(ProcessedData::getInstance().getHits());
   drawMarkers(ProcessedData::getInstance().getHits());
+  //std::cout << "state: " << fSaveMarkersAndLinesBetweenEvents << "\n";
+
   updateCanvas(fCanvas3d);
   updateCanvas(fCanvas2d);
-  updateCanvas(fCanvas2d2);
+  updateCanvas(fCanvasTopView);
   updateCanvas(fCanvasDiagrams);
 }
 
@@ -58,14 +60,14 @@ void GeometryVisualizator::showGeometry()
 {
   assert(fRootCanvas3d);
   assert(fRootCanvas2d);
-  assert(fRootCanvas2d2);
+  assert(fRootCanvasTopView);
   assert(fRootCanvasDiagrams);
   if (!fCanvas3d)
     fCanvas3d = std::unique_ptr<TCanvas>(fRootCanvas3d->GetCanvas());
   if (!fCanvas2d)
     fCanvas2d = std::unique_ptr<TCanvas>(fRootCanvas2d->GetCanvas());
-  if (!fCanvas2d2)
-    fCanvas2d2 = std::unique_ptr<TCanvas>(fRootCanvas2d2->GetCanvas());
+  if (!fCanvasTopView)
+    fCanvasTopView = std::unique_ptr<TCanvas>(fRootCanvasTopView->GetCanvas());
   if (!fCanvasDiagrams)
     fCanvasDiagrams =
         std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
@@ -183,7 +185,7 @@ void GeometryVisualizator::setVisibility2d(
                          ((allScintilatorsCanv[layer][strip].image->GetY2() -
                            allScintilatorsCanv[layer][strip].image->GetY1()) /
                           2);
-        std::cout << "marker center: " << centerX << "  " << centerY << "\n";
+        //std::cout << "marker center: " << centerX << "  " << centerY << "\n";
         allScintilatorsCanv[layer][strip].event =
             new TMarker(centerX, centerY, 3);
         allScintilatorsCanv[layer][strip].event->SetMarkerColor(2);
@@ -235,50 +237,85 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
 
 void GeometryVisualizator::drawMarkers(const HitPositions &pos)
 {
-  fCanvas2d2->cd();
-  TPolyLine *line = new TPolyLine();
-  line->SetLineWidth(2);
-  line->SetLineColor(kRed);
-  line->SetLineStyle(4);
-  TPolyMarker *pm = new TPolyMarker();
-  pm->SetMarkerSize(2);
-  pm->SetMarkerColor(kBlack);
-  pm->SetMarkerStyle(2);
+  fCanvasTopView->cd();
+  int vectorLineSize = fLineOnTopView.size();
+  int vectorMarkerSize = fMarkerOnTopView.size();
+  if(!fSaveMarkersAndLinesBetweenEvents)
+  {
+    for(TPolyLine * line : fLineOnTopView)
+    {
+      fCanvasTopView->GetListOfPrimitives()->Remove(line);
+      delete line;
+    }
+    fLineOnTopView.clear();
+    for(TPolyMarker * marker : fMarkerOnTopView)
+    {
+      fCanvasTopView->GetListOfPrimitives()->Remove(marker);
+      delete marker;
+    }
+    fMarkerOnTopView.clear();
+  }
+  fLineOnTopView.push_back(new TPolyLine());
+  fMarkerOnTopView.push_back(new TPolyMarker());
   for (Int_t jc = 0; jc < pos.size(); jc++)
   {
-    line->SetPoint(jc, pos[jc].Y(), pos[jc].X());
-    pm->SetPoint(jc, pos[jc].Y(), pos[jc].X());
+    fLineOnTopView.back()->SetLineWidth(2);
+    fLineOnTopView.back()->SetLineColor(kRed);
+    fLineOnTopView.back()->SetLineStyle(4);
+    fLineOnTopView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X());
+
+    fMarkerOnTopView.back()->SetMarkerSize(2);
+    fMarkerOnTopView.back()->SetMarkerColor(kBlack);
+    fMarkerOnTopView.back()->SetMarkerStyle(2);
+    fMarkerOnTopView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X());
   }
-  line->Draw();
-  pm->Draw();
+  fLineOnTopView.back()->Draw();
+  fMarkerOnTopView.back()->Draw();
 }
 
 void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 {
   fCanvas3d->cd();
-  std::cout << "pos size: " << pos.size() << "\n";
-  TPolyLine3D *line = new TPolyLine3D();
-  line->SetLineWidth(2);
-  line->SetLineColor(kRed);
-  line->SetLineStyle(4);
-  TPolyMarker3D *pm3d1 = new TPolyMarker3D();
-  pm3d1->SetMarkerSize(2);
-  pm3d1->SetMarkerColor(kBlack);
-  pm3d1->SetMarkerStyle(2);
+  int vectorLineSize = fLineOn3dView.size();
+  int vectorMarkerSize = fMarkerOn3dView.size();
+  if(!fSaveMarkersAndLinesBetweenEvents)
+  {
+    for(TPolyLine3D * line : fLineOn3dView)
+    {
+      fCanvas3d->GetListOfPrimitives()->Remove(line);
+      delete line;
+    }
+    fLineOn3dView.clear();
+    for(TPolyMarker3D * marker : fMarkerOn3dView)
+    {
+      fCanvas3d->GetListOfPrimitives()->Remove(marker);
+      delete marker;
+    }
+    fMarkerOn3dView.clear();
+  }
+  fLineOn3dView.push_back(new TPolyLine3D());
+  fMarkerOn3dView.push_back(new TPolyMarker3D());
   for (Int_t jc = 0; jc < pos.size(); jc++)
   {
-    line->SetPoint(jc, pos[jc].Y(), pos[jc].X(), pos[jc].Z());
-    pm3d1->SetPoint(jc, pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+    fLineOn3dView.back()->SetLineWidth(2);
+    fLineOn3dView.back()->SetLineColor(kRed);
+    fLineOn3dView.back()->SetLineStyle(4);
+    fLineOn3dView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X(), pos[jc].Z());
+
+    fMarkerOn3dView.back()->SetMarkerSize(2);
+    fMarkerOn3dView.back()->SetMarkerColor(kBlack);
+    fMarkerOn3dView.back()->SetMarkerStyle(2);
+    fMarkerOn3dView.back()->SetNextPoint(pos[jc].Y(), pos[jc].X(), pos[jc].Z());
   }
-  line->Draw();
-  pm3d1->Draw();
+  fLineOn3dView.back()->Draw();
+  fMarkerOn3dView.back()->Draw();
 }
 
 void GeometryVisualizator::draw2dGeometry2()
 {
   const double canvasRange = 100;
-  fCanvas2d2->cd();
-  fCanvas2d2->Range(-canvasRange, -canvasRange, canvasRange, canvasRange);
+  fCanvasTopView->cd();
+  fCanvasTopView->Range(-canvasRange, -canvasRange, canvasRange, canvasRange);
   TEllipse *thirdLayerCircle = new TEllipse(0, 0, 57.5, 57.5);
   thirdLayerCircle->Draw();
   TEllipse *secondLayerCircle = new TEllipse(0, 0, 46.75, 46.75);
@@ -327,7 +364,7 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     fCanvasDiagrams =
         std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
   int vectorSize = diagramData.size();
-  std::cout << "vector size: " << vectorSize << "\n";
+  //std::cout << "vector size: " << vectorSize << "\n";
   fCanvasDiagrams->cd();
   if (vectorSize != fLastDiagramVectorSize)
   {

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -28,9 +28,9 @@ namespace jpet_event_display
 GeometryVisualizator::GeometryVisualizator(
     const int numberOfLayers, const int scintillatorLenght,
     const std::vector< std::pair< int, double > > &layerStats)
-    : fScinLenghtWithoutScale(kLength)
+    : fScinLenghtWithoutScale(scintillatorLenght)
 {
-  createGeometry(numberOfLayers, kLength, layerStats);
+  createGeometry(numberOfLayers, scintillatorLenght, layerStats);
 }
 
 GeometryVisualizator::~GeometryVisualizator() {}

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -26,7 +26,7 @@ namespace jpet_event_display
 {
 
 GeometryVisualizator::GeometryVisualizator(
-    const int numberOfLayers, const int kLength,
+    const int numberOfLayers, const int scintillatorLenght,
     const std::vector< std::pair< int, double > > &layerStats)
     : fScinLenghtWithoutScale(kLength)
 {

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -419,9 +419,6 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     std::vector< float > leadingY;
     std::vector< float > trailingX;
     std::vector< float > trailingY;
-    // double x[n], y[n];
-    // int i = 0;
-    // double minValue = 9999999;
     double changePsToNs = 0.001;
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
@@ -437,9 +434,6 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
                             changePsToNs);
         trailingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
-      // if (x[i] < minValue)
-      //  minValue = x[i];
-      // i++;
     }
     TMultiGraph *mg = new TMultiGraph();
 
@@ -457,9 +451,6 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     {
       TGraph *gr =
           new TGraph(leadingX.size(), leadingX.data(), leadingY.data());
-      gr->GetXaxis()->SetTitle("Time");
-      // gr->GetXaxis()->SetLimits(minValue - 10, minValue + 20);
-      gr->GetYaxis()->SetTitle("Threshold Number");
       mg->Add(gr);
     }
 
@@ -467,21 +458,20 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     {
       TGraph *gr2 =
           new TGraph(trailingX.size(), trailingX.data(), trailingY.data());
-      gr2->GetXaxis()->SetTitle("Time");
-      gr2->GetYaxis()->SetTitle("Threshold Number");
       gr2->SetMarkerColor(kRed);
 
       mg->Add(gr2);
     }
 
     mg->Draw("AP*");
+    mg->GetYaxis()->SetLabelOffset(999);
+    mg->GetYaxis()->SetTickLength(0);
     mg->GetYaxis()->SetRangeUser(0, 5);
-
     mg->GetXaxis()->SetLimits(mg->GetXaxis()->GetXmin(),
                               mg->GetXaxis()->GetXmax());
     mg->GetXaxis()->SetNdivisions(504, kFALSE);
-    mg->GetYaxis()->SetLabelOffset(999);
-    mg->GetYaxis()->SetTickLength(0);
+    mg->GetXaxis()->SetTitle("Time");
+    mg->GetYaxis()->SetTitle("Threshold Number");
 
     for (int k = 0; k < 4; k++)
     {

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -480,8 +480,8 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     mg->GetXaxis()->SetLimits(mg->GetXaxis()->GetXmin(),
                               mg->GetXaxis()->GetXmax());
     mg->GetXaxis()->SetNdivisions(504, kFALSE);
-    // mg->GetYaxis()->SetLabelOffset(999);
-    // mg->GetYaxis()->SetTickLength(0);
+    mg->GetYaxis()->SetLabelOffset(999);
+    mg->GetYaxis()->SetTickLength(0);
 
     for (int k = 0; k < 4; k++)
     {

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -529,13 +529,19 @@ float GeometryVisualizator::changeSignalNumber(int signalNumber)
                                                   // threshold is on top
 }
 
+/* Function creating 3d geometry of tomograph
+  numberOfLayers - number of layers in tomograph
+  scintillatorLenght - lenght of each scintillator
+  layerStats - vector of pair for each layer with number of scintillator in
+  layer and radius from center of that layer
+*/
 void GeometryVisualizator::createGeometry(
-    const int numberOfLayers, const int kLength,
+    const int numberOfLayers, const int scintillatorLenght,
     const std::vector< std::pair< int, double > > &layerStats)
 {
-  const double kXWorld = kLength + 100;
-  const double kYWorld = kLength + 100;
-  const double kZWorld = kLength + 100;
+  const double kXWorld = scintillatorLenght + 100;
+  const double kYWorld = scintillatorLenght + 100;
+  const double kZWorld = scintillatorLenght + 100;
 
   const double kLayerThickness = 0.9;
   gSystem->Load("libGeom");
@@ -564,8 +570,9 @@ void GeometryVisualizator::createGeometry(
 
   for (int i = 0; i < numberOfLayers; i++)
   {
-    TGeoTube *layer = new TGeoTube(
-        layerStats[i].second, layerStats[i].second + kLayerThickness, kLength);
+    TGeoTube *layer = new TGeoTube(layerStats[i].second,
+                                   layerStats[i].second + kLayerThickness,
+                                   scintillatorLenght);
     assert(layer);
     layers.push_back(layer);
   }
@@ -586,8 +593,6 @@ void GeometryVisualizator::createGeometry(
     for (int j = 0; j < layerStats[i].first; j++)
     {
       TGeoVolume *scin = gGeoManager->MakeTube("scin", medium, 0, 0.7, 50);
-      // scin->SetLineWidth(5);
-      // scin->SetLineColor(layersColors[i]);
 
       scin->SetLineColorAlpha(layersColors[i], 0.3);
       vol->AddNode(
@@ -603,6 +608,5 @@ void GeometryVisualizator::createGeometry(
   }
   fGeoManager->CloseGeometry();
   fGeoManager->SetVisLevel(4);
-  // fGeoManager->Export("tt.root");
 }
 }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -275,20 +275,23 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     int i = 0;
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
-      y[i] = static_cast<double>(it->first);
+      y[i] = static_cast<double>(std::get<0>(*it));
       //y[i] = static_cast<double>(it->second.first);
-      x[i] = static_cast<double>(it->second.second);
+      x[i] = static_cast<double>(std::get<2>(*it));
       // std::cout << "x: " << x[i] << " y: " << y[i] << "\n";
       i++;
     }
     TGraph *gr = new TGraph(n, x, y);
     gr->GetXaxis()->SetTitle("Time");
     gr->GetYaxis()->SetTitle("Threshold Number");
-    gr->Draw("ACP*");
-    TLine *line =
-        new TLine(gr->GetXaxis()->GetXmin(), 1, gr->GetXaxis()->GetXmax(), 1);
-    line->SetLineColor(kRed);
-    line->Draw();
+    gr->Draw("AP*");//ACP*
+    for (int k = 0; k < 4; k++)
+    {
+      TLine *line =
+          new TLine(gr->GetXaxis()->GetXmin(), k + 1, gr->GetXaxis()->GetXmax(), k + 1);
+      line->SetLineColor(kRed);
+      line->Draw();
+    }
   }
 
 }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -258,6 +258,12 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
   for (auto iter = selection.begin(); iter != selection.end(); ++iter)
   {
     layer = iter->first;
+    if(layer == JPetGeomMapping::kBadLayerNumber)
+    {
+      std::cout << "/* Bad layer number in setVisibility, returning...*/" << "\n";
+      //Error("Bad layer number in setVisibility, returning...");
+      return;
+    }
     const std::vector< size_t > &strips = iter->second;
     nodeLayer = topNode->GetDaughter(layer - 1);
     assert(nodeLayer);
@@ -266,6 +272,12 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
          ++stripIter)
     {
       strip = *stripIter;
+      if(strip == JPetGeomMapping::kBadSlotNumber)
+      {
+        std::cout << "/* Bad strip number in setVisibility, returning...*/" << "\n";
+        //Error("Bad strip number in setVisibility, returning...");
+        return;
+      }
       nodeStrip = nodeLayer->GetDaughter(strip - 1);
       assert(nodeStrip);
       nodeStrip->GetVolume()->SetLineColor(kRed);

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -83,7 +83,7 @@ void GeometryVisualizator::showGeometry()
   fCanvas3d->cd();
   assert(fGeoManager);
   Int_t irep;
-  fGeoManager->GetTopVolume()->Draw();
+  fGeoManager->GetTopVolume()->Draw("ogl");
   assert(gPad);
   TView *view = gPad->GetView();
   assert(view);
@@ -576,7 +576,7 @@ void GeometryVisualizator::createGeometry(
     for (int j = 0; j < layerStats[i].first; j++)
     {
       TGeoVolume *scin = gGeoManager->MakeTube("scin", medium, 0, 0.7, 50);
-      scin->SetLineWidth(5);
+      // scin->SetLineWidth(5);
       // scin->SetLineColor(layersColors[i]);
 
       scin->SetLineColorAlpha(layersColors[i], 0.3);
@@ -592,7 +592,7 @@ void GeometryVisualizator::createGeometry(
     i++;
   }
   fGeoManager->CloseGeometry();
-  fGeoManager->SetVisLevel(0);
-  fGeoManager->Export("tt.root");
+  fGeoManager->SetVisLevel(4);
+  // fGeoManager->Export("tt.root");
 }
 }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -460,19 +460,17 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     std::vector< float > leadingY;
     std::vector< float > trailingX;
     std::vector< float > trailingY;
-    const float changePsToNs = 0.001;
+    const float kPsToNs = 0.001;
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
       if (std::get< 3 >(*it) == JPetSigCh::Leading)
       {
-        leadingX.push_back(static_cast< float >(std::get< 2 >(*it)) *
-                           changePsToNs);
+        leadingX.push_back(static_cast< float >(std::get< 2 >(*it)) * kPsToNs);
         leadingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
       else
       {
-        trailingX.push_back(static_cast< float >(std::get< 2 >(*it)) *
-                            changePsToNs);
+        trailingX.push_back(static_cast< float >(std::get< 2 >(*it)) * kPsToNs);
         trailingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
     }
@@ -509,13 +507,12 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     mg->GetYaxis()->SetTickLength(0);
     mg->GetYaxis()->SetRangeUser(0, 5);
     mg->GetXaxis()->SetLimits(0, 50);
-    // mg->GetXaxis()->SetLimits(mg->GetXaxis()->GetXmin() - 10 * 1000,
-    //                          mg->GetXaxis()->GetXmin() + 20 * 1000);
     mg->GetXaxis()->SetNdivisions(504, kFALSE);
     mg->GetXaxis()->SetTitle("Time (ns)");
     mg->GetYaxis()->SetTitle("Threshold Number");
 
-    for (int k = 0; k < 4; k++)
+    int kNumberOfThresholds = 4;
+    for (int k = 0; k < kNumberOfThresholds; k++)
     {
       TLine *line = new TLine(mg->GetXaxis()->GetXmin(), k + 1,
                               mg->GetXaxis()->GetXmax(), k + 1);
@@ -525,19 +522,11 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
   }
 }
 
-float GeometryVisualizator::changeSignalNumber(
-    int signalNumber) // change this...
+float GeometryVisualizator::changeSignalNumber(int signalNumber)
 {
-  // std::cout << "signalNumber: " << signalNumber << "\n";
-  if (signalNumber == 4)
-    return 1.;
-  if (signalNumber == 3)
-    return 2.;
-  if (signalNumber == 2)
-    return 3.;
-  if (signalNumber == 1)
-    return 4.;
-  return 0.;
+  return static_cast< float >(-signalNumber + 5); // reversing threshold number
+                                                  // in graph 1->4 etc, so first
+                                                  // threshold is on top
 }
 
 void GeometryVisualizator::reverseYAxis(TGraph *g)

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -40,14 +40,14 @@ void GeometryVisualizator::drawData()
   drawStrips(ProcessedData::getInstance().getActivedScintilators());
   drawDiagram(ProcessedData::getInstance().getDiagramData());
   drawLineBetweenActivedScins(ProcessedData::getInstance().getHits());
-
+  drawMarkers(ProcessedData::getInstance().getHits());
   updateCanvas(fCanvas3d);
   updateCanvas(fCanvas2d);
   updateCanvas(fCanvas2d2);
   updateCanvas(fCanvasDiagrams);
 }
 
-void GeometryVisualizator::updateCanvas(std::unique_ptr<TCanvas>& canvas)
+void GeometryVisualizator::updateCanvas(std::unique_ptr<TCanvas> &canvas)
 {
   canvas->Draw();
   canvas->Update();
@@ -62,17 +62,17 @@ void GeometryVisualizator::showGeometry()
   assert(fRootCanvasDiagrams);
   if (!fCanvas3d)
     fCanvas3d = std::unique_ptr<TCanvas>(fRootCanvas3d->GetCanvas());
-  if(!fCanvas2d)
+  if (!fCanvas2d)
     fCanvas2d = std::unique_ptr<TCanvas>(fRootCanvas2d->GetCanvas());
   if (!fCanvas2d2)
     fCanvas2d2 = std::unique_ptr<TCanvas>(fRootCanvas2d2->GetCanvas());
-  if(!fCanvasDiagrams)
+  if (!fCanvasDiagrams)
     fCanvasDiagrams =
         std::unique_ptr<TCanvas>(fRootCanvasDiagrams->GetCanvas());
 
   draw2dGeometry();
   setAllStripsUnvisible();
-  //setAllStripsUnvisible2d();
+  // setAllStripsUnvisible2d();
 
   draw2dGeometry2();
 
@@ -85,7 +85,7 @@ void GeometryVisualizator::showGeometry()
   assert(view);
   view->ZoomView(gPad, 1.75);
   view->SetView(0, 90, 0, irep);
-  if(irep == -1)
+  if (irep == -1)
     WARNING("Error in min-max scope setting view to 3d canvas");
 
   gPad->Modified();
@@ -101,7 +101,7 @@ void GeometryVisualizator::draw2dGeometry()
   const int leftMargin = 20;
   const int rightMargin = 20;
   const int canvasScale = 900;
-  //int startX = canvasScale - leftMargin;
+  // int startX = canvasScale - leftMargin;
   int startY = canvasScale - topMargin;
   int canvasWidth = canvasScale - leftMargin - rightMargin;
   int canvasHeight = canvasScale - topMargin - bottomMargin;
@@ -177,10 +177,12 @@ void GeometryVisualizator::setVisibility2d(
         double scale = scaledScinLenght / fScinLenghtWithoutScale;
         double centerX = allScintilatorsCanv[layer][strip].image->GetX1() +
                          ((allScintilatorsCanv[layer][strip].image->GetX2() -
-                           allScintilatorsCanv[layer][strip].image->GetX1()) / 2);
+                           allScintilatorsCanv[layer][strip].image->GetX1()) /
+                          2);
         double centerY = allScintilatorsCanv[layer][strip].image->GetY1() +
                          ((allScintilatorsCanv[layer][strip].image->GetY2() -
-                         allScintilatorsCanv[layer][strip].image->GetY1()) / 2);
+                           allScintilatorsCanv[layer][strip].image->GetY1()) /
+                          2);
         std::cout << "marker center: " << centerX << "  " << centerY << "\n";
         allScintilatorsCanv[layer][strip].event =
             new TMarker(centerX, centerY, 3);
@@ -203,7 +205,6 @@ void GeometryVisualizator::drawStrips(const ScintillatorsInLayers &selection)
   setVisibility(selection);
   setVisibility2d(selection);
 }
-
 
 void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
 {
@@ -232,6 +233,26 @@ void GeometryVisualizator::setVisibility(const ScintillatorsInLayers &selection)
   }
 }
 
+void GeometryVisualizator::drawMarkers(const HitPositions &pos)
+{
+  fCanvas2d2->cd();
+  TPolyLine *line = new TPolyLine();
+  line->SetLineWidth(2);
+  line->SetLineColor(kRed);
+  line->SetLineStyle(4);
+  TPolyMarker *pm = new TPolyMarker();
+  pm->SetMarkerSize(2);
+  pm->SetMarkerColor(kBlack);
+  pm->SetMarkerStyle(2);
+  for (Int_t jc = 0; jc < pos.size(); jc++)
+  {
+    line->SetPoint(jc, pos[jc].Y(), pos[jc].X());
+    pm->SetPoint(jc, pos[jc].Y(), pos[jc].X());
+  }
+  line->Draw();
+  pm->Draw();
+}
+
 void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 {
   fCanvas3d->cd();
@@ -255,30 +276,21 @@ void GeometryVisualizator::drawLineBetweenActivedScins(const HitPositions &pos)
 
 void GeometryVisualizator::draw2dGeometry2()
 {
+  const double canvasRange = 100;
   fCanvas2d2->cd();
-  const double firstLayerRadius = 0.2956;
-  const double secondLayerRadius = 0.3252;
-  const double thirdLayerRadius = 0.4;
-  const double middle = 0.5;
-  TEllipse *thirdLayerCircle =
-      new TEllipse(middle, middle, thirdLayerRadius, thirdLayerRadius);
+  fCanvas2d2->Range(-canvasRange, -canvasRange, canvasRange, canvasRange);
+  TEllipse *thirdLayerCircle = new TEllipse(0, 0, 57.5, 57.5);
   thirdLayerCircle->Draw();
-  TEllipse *secondLayerCircle =
-      new TEllipse(middle, middle, secondLayerRadius, secondLayerRadius);
+  TEllipse *secondLayerCircle = new TEllipse(0, 0, 46.75, 46.75);
   secondLayerCircle->Draw();
-  TEllipse *firstLayerCircle =
-      new TEllipse(middle, middle, firstLayerRadius, firstLayerRadius);
+  TEllipse *firstLayerCircle = new TEllipse(0, 0, 42.5, 42.5);
   firstLayerCircle->Draw();
 
-  TEllipse *testScin =
-      new TEllipse(middle, middle, firstLayerRadius, firstLayerRadius, 0, 360/48);
-  testScin->Draw();
-
-  TGaxis *axisX = new TGaxis(0.1, 0.5, 0.9, 0.5, -57.5, 57.5, 50510, "");
+  TGaxis *axisX = new TGaxis(-57.5, 0, 57.5, 0, -57.5, 57.5, 50510, "");
   axisX->SetName("axisX");
   axisX->Draw();
 
-  TGaxis *axisY = new TGaxis(0.5, 0.1, 0.5, 0.9, -57.5, 57.5, 50510, "");
+  TGaxis *axisY = new TGaxis(0, -57.5, 0, 57.5, -57.5, 57.5, 50510, "");
   axisY->SetName("axisY");
   axisY->Draw();
 }
@@ -287,7 +299,7 @@ void GeometryVisualizator::setAllStripsUnvisible()
 {
   assert(fGeoManager);
   TGeoNodeMatrix *topNode =
-      static_cast < TGeoNodeMatrix * >(fGeoManager->GetTopNode());
+      static_cast<TGeoNodeMatrix *>(fGeoManager->GetTopNode());
   assert(topNode);
   int fNumberOfLayers = topNode->GetNdaughters();
   TGeoNode *node = 0;
@@ -317,7 +329,7 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
   int vectorSize = diagramData.size();
   std::cout << "vector size: " << vectorSize << "\n";
   fCanvasDiagrams->cd();
-  if(vectorSize != fLastDiagramVectorSize)
+  if (vectorSize != fLastDiagramVectorSize)
   {
     fCanvasDiagrams->Clear();
     fCanvasDiagrams->DivideSquare(vectorSize);
@@ -333,7 +345,7 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++)
     {
       y[i] = static_cast<double>(std::get<0>(*it));
-      //y[i] = static_cast<double>(it->second.first);
+      // y[i] = static_cast<double>(it->second.first);
       x[i] = static_cast<double>(std::get<2>(*it));
       // std::cout << "x: " << x[i] << " y: " << y[i] << "\n";
       i++;
@@ -341,16 +353,15 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector &diagramData)
     TGraph *gr = new TGraph(n, x, y);
     gr->GetXaxis()->SetTitle("Time");
     gr->GetYaxis()->SetTitle("Threshold Number");
-    gr->Draw("AP*");//ACP*
+    gr->Draw("AP*"); // ACP*
     for (int k = 0; k < 4; k++)
     {
-      TLine *line =
-          new TLine(gr->GetXaxis()->GetXmin(), k + 1, gr->GetXaxis()->GetXmax(), k + 1);
+      TLine *line = new TLine(gr->GetXaxis()->GetXmin(), k + 1,
+                              gr->GetXaxis()->GetXmax(), k + 1);
       line->SetLineColor(kRed);
       line->Draw();
     }
   }
-
 }
 
 void GeometryVisualizator::createGeometry(
@@ -388,9 +399,8 @@ void GeometryVisualizator::createGeometry(
 
   for (int i = 0; i < numberOfLayers; i++)
   {
-    TGeoTube *layer =
-        new TGeoTube(layerStats[i].second,
-                     layerStats[i].second + kLayerThickness, kLength);
+    TGeoTube *layer = new TGeoTube(
+        layerStats[i].second, layerStats[i].second + kLayerThickness, kLength);
     assert(layer);
     layers.push_back(layer);
   }
@@ -426,5 +436,4 @@ void GeometryVisualizator::createGeometry(
   fGeoManager->CloseGeometry();
   fGeoManager->SetVisLevel(4);
 }
-
 }

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -31,12 +31,14 @@
 #include <TMultiGraph.h>
 #include <TPoint.h>
 #include <TPolyLine.h>
+#include <TPolyLine3D.h>
 #include <TPolyMarker.h>
 #include <TPolyMarker3D.h>
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TView.h>
 #include <TVirtualPad.h>
+#include <TObject.h>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -68,13 +70,18 @@ public:
   {
     return fRootCanvas2d;
   }
-  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas2d2()
+  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvasTopView()
   {
-    return fRootCanvas2d2;
+    return fRootCanvasTopView;
   }
   inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvasDiagrams()
   {
     return fRootCanvasDiagrams;
+  }
+
+  inline void changeMarkersState()
+  {
+    fSaveMarkersAndLinesBetweenEvents = !fSaveMarkersAndLinesBetweenEvents;
   }
 
 private:
@@ -110,16 +117,24 @@ private:
   int *numberOfScintilatorsInLayer;
   std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas3d;
   std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d;
-  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d2;
+  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasTopView;
   std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasDiagrams;
   std::unique_ptr<TCanvas> fCanvas3d;
   std::unique_ptr<TCanvas> fCanvas2d;
-  std::unique_ptr<TCanvas> fCanvas2d2;
+  std::unique_ptr<TCanvas> fCanvasTopView;
   std::unique_ptr<TCanvas> fCanvasDiagrams;
 
   int fScinLenghtWithoutScale = 0;
 
   int fLastDiagramVectorSize = 0;
+
+  bool fSaveMarkersAndLinesBetweenEvents = false;
+
+  std::vector<TPolyLine3D *> fLineOn3dView;
+  std::vector<TPolyMarker3D *>fMarkerOn3dView;
+
+  std::vector<TPolyLine *>fLineOnTopView;
+  std::vector<TPolyMarker *>fMarkerOnTopView;
 #endif
 
   struct ScintillatorCanv

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -107,7 +107,7 @@ private:
   void drawMarkers(const HitPositions &pos);
   void drawDiagram(const DiagramDataMapVector &diagramData);
   void reverseYAxis(TGraph *g);
-  double changeSignalNumber(int signalNumber);
+  float changeSignalNumber(int signalNumber);
 
   void draw2dGeometry2();
 
@@ -116,7 +116,10 @@ private:
     kBlack = 1,
     kRed = 2,
     kBlue = 34,
-    kGreen = 30
+    kGreen = 30,
+    kGray1 = 921,
+    kGray2 = 922,
+    kGray3 = 923,
   };
   std::unique_ptr< TGeoManager > fGeoManager;
   std::unique_ptr< TRootEmbeddedCanvas > fRootCanvas3d;
@@ -142,6 +145,7 @@ private:
 
   std::vector< std::vector< TBox * > > fUnRolledViewScintillators;
   std::vector< TMarker * > fUnRolledViewMarker;
+  ColorTable layersColors[3]{kGray1, kGray2, kGray3};
 #endif
 
   /*struct ScintillatorCanv

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -39,6 +39,7 @@
 #include <TSystem.h>
 #include <TView.h>
 #include <TVirtualPad.h>
+
 #include <cassert>
 #include <map>
 #include <memory>

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -48,7 +48,7 @@ namespace jpet_event_display
   class GeometryVisualizator
   {
   public:
-    GeometryVisualizator(const int numberOfLayers,
+    GeometryVisualizator(const int numberOfLayers, const int kLength,
                          const std::vector<std::pair<int, double>> &layerStats);
     ~GeometryVisualizator();
     
@@ -66,8 +66,8 @@ namespace jpet_event_display
 
 
 #ifndef __CINT__
-    void createGeometry(const int numberOfLayers,
-                        const std::vector<std::pair<int, double>>& layerStats);
+    void createGeometry(const int numberOfLayers, const int kLength,
+                        const std::vector<std::pair<int, double>> &layerStats);
 
     void updateCanvas(std::unique_ptr<TCanvas> &canvas);
 

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -32,6 +32,9 @@
 #include <TView.h>
 #include <TVirtualPad.h>
 #include <TPoint.h>
+#include <TPolyMarker3D.h>
+#include <TEllipse.h>
+#include <TGaxis.h>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -56,11 +59,9 @@ namespace jpet_event_display
     void showGeometry();
     void drawData();
 
-    inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas3d()
-    {
-      return fRootCanvas3d;
-    }
+    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas3d() { return fRootCanvas3d; }
     inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d() { return fRootCanvas2d; }
+    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d2() { return fRootCanvas2d2; }
     inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvasDiagrams() { return fRootCanvasDiagrams; }
 
   private: 
@@ -79,17 +80,30 @@ namespace jpet_event_display
     void setAllStripsUnvisible2d();
     void setVisibility(const ScintillatorsInLayers& selection);
     void setVisibility2d(const ScintillatorsInLayers& selection);
-    void drawDiagram(const DiagramDataMapVector& diagramData);
 
-    enum ColorTable { kBlack = 1, kRed = 2, kBlue = 34, kGreen = 30 };
+    void drawLineBetweenActivedScins(const HitPositions &pos);
+
+    void drawDiagram(const DiagramDataMapVector &diagramData);
+
+    void draw2dGeometry2();
+
+    enum ColorTable
+    {
+      kBlack = 1,
+      kRed = 2,
+      kBlue = 34,
+      kGreen = 30
+    };
     std::unique_ptr<TGeoManager> fGeoManager;
     int numberOfLayers = 0;
     int* numberOfScintilatorsInLayer; 
     std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas3d;
     std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d;
+    std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d2;
     std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasDiagrams;
     std::unique_ptr<TCanvas> fCanvas3d;
     std::unique_ptr<TCanvas> fCanvas2d;
+    std::unique_ptr<TCanvas> fCanvas2d2;
     std::unique_ptr<TCanvas> fCanvasDiagrams;
 
     int fScinLenghtWithoutScale = 0;

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -29,6 +29,7 @@
 #include <TLine.h>
 #include <TMarker.h>
 #include <TMultiGraph.h>
+#include <TObject.h>
 #include <TPoint.h>
 #include <TPolyLine.h>
 #include <TPolyLine3D.h>
@@ -38,7 +39,6 @@
 #include <TSystem.h>
 #include <TView.h>
 #include <TVirtualPad.h>
-#include <TObject.h>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -55,26 +55,27 @@ namespace jpet_event_display
 class GeometryVisualizator
 {
 public:
-  GeometryVisualizator(const int numberOfLayers, const int kLength,
-                       const std::vector<std::pair<int, double>> &layerStats);
+  GeometryVisualizator(
+      const int numberOfLayers, const int kLength,
+      const std::vector< std::pair< int, double > > &layerStats);
   ~GeometryVisualizator();
 
   void showGeometry();
   void drawData();
 
-  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas3d()
+  inline std::unique_ptr< TRootEmbeddedCanvas > &getCanvas3d()
   {
     return fRootCanvas3d;
   }
-  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas2d()
+  inline std::unique_ptr< TRootEmbeddedCanvas > &getCanvas2d()
   {
     return fRootCanvas2d;
   }
-  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvasTopView()
+  inline std::unique_ptr< TRootEmbeddedCanvas > &getCanvasTopView()
   {
     return fRootCanvasTopView;
   }
-  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvasDiagrams()
+  inline std::unique_ptr< TRootEmbeddedCanvas > &getCanvasDiagrams()
   {
     return fRootCanvasDiagrams;
   }
@@ -86,10 +87,11 @@ public:
 
 private:
 #ifndef __CINT__
-  void createGeometry(const int numberOfLayers, const int kLength,
-                      const std::vector<std::pair<int, double>> &layerStats);
+  void
+  createGeometry(const int numberOfLayers, const int kLength,
+                 const std::vector< std::pair< int, double > > &layerStats);
 
-  void updateCanvas(std::unique_ptr<TCanvas> &canvas);
+  void updateCanvas(std::unique_ptr< TCanvas > &canvas);
 
   void draw2dGeometry();
   void drawStrips(const ScintillatorsInLayers &selection);
@@ -112,17 +114,15 @@ private:
     kBlue = 34,
     kGreen = 30
   };
-  std::unique_ptr<TGeoManager> fGeoManager;
-  int numberOfLayers = 0;
-  int *numberOfScintilatorsInLayer;
-  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas3d;
-  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d;
-  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasTopView;
-  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasDiagrams;
-  std::unique_ptr<TCanvas> fCanvas3d;
-  std::unique_ptr<TCanvas> fCanvas2d;
-  std::unique_ptr<TCanvas> fCanvasTopView;
-  std::unique_ptr<TCanvas> fCanvasDiagrams;
+  std::unique_ptr< TGeoManager > fGeoManager;
+  std::unique_ptr< TRootEmbeddedCanvas > fRootCanvas3d;
+  std::unique_ptr< TRootEmbeddedCanvas > fRootCanvas2d;
+  std::unique_ptr< TRootEmbeddedCanvas > fRootCanvasTopView;
+  std::unique_ptr< TRootEmbeddedCanvas > fRootCanvasDiagrams;
+  std::unique_ptr< TCanvas > fCanvas3d;
+  std::unique_ptr< TCanvas > fCanvas2d;
+  std::unique_ptr< TCanvas > fCanvasTopView;
+  std::unique_ptr< TCanvas > fCanvasDiagrams;
 
   int fScinLenghtWithoutScale = 0;
 
@@ -130,20 +130,23 @@ private:
 
   bool fSaveMarkersAndLinesBetweenEvents = false;
 
-  std::vector<TPolyLine3D *> fLineOn3dView;
-  std::vector<TPolyMarker3D *>fMarkerOn3dView;
+  std::vector< TPolyLine3D * > fLineOn3dView;
+  std::vector< TPolyMarker3D * > fMarkerOn3dView;
 
-  std::vector<TPolyLine *>fLineOnTopView;
-  std::vector<TPolyMarker *>fMarkerOnTopView;
+  std::vector< TPolyLine * > fLineOnTopView;
+  std::vector< TPolyMarker * > fMarkerOnTopView;
+
+  std::vector< std::vector< TBox * > > fUnRolledViewScintillators;
+  std::vector< TMarker * > fUnRolledViewMarker;
 #endif
 
-  struct ScintillatorCanv
+  /*struct ScintillatorCanv
   {
     TBox *image;
     TMarker *event;
   } fScintCanv;
   ScintillatorCanv fScintCanv2;
-  ScintillatorCanv **allScintilatorsCanv;
+  ScintillatorCanv **allScintilatorsCanv;*/
 };
 }
 #endif // GEOMETRYVISUALIZATOR_H_

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -57,7 +57,7 @@ class GeometryVisualizator
 {
 public:
   GeometryVisualizator(
-      const int numberOfLayers, const int kLength,
+      const int numberOfLayers, const int scintillatorLenght,
       const std::vector< std::pair< int, double > > &layerStats);
   ~GeometryVisualizator();
 
@@ -89,7 +89,7 @@ public:
 private:
 #ifndef __CINT__
   void
-  createGeometry(const int numberOfLayers, const int kLength,
+  createGeometry(const int numberOfLayers, const int scintillatorLenght,
                  const std::vector< std::pair< int, double > > &layerStats);
 
   void updateCanvas(std::unique_ptr< TCanvas > &canvas);

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -31,6 +31,7 @@
 #include <TSystem.h>
 #include <TView.h>
 #include <TVirtualPad.h>
+#include <TPoint.h>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -90,6 +91,10 @@ namespace jpet_event_display
     std::unique_ptr<TCanvas> fCanvas3d;
     std::unique_ptr<TCanvas> fCanvas2d;
     std::unique_ptr<TCanvas> fCanvasDiagrams;
+
+    int fScinLenghtWithoutScale = 0;
+
+    int fLastDiagramVectorSize = 0;
 #endif
 
     struct ScintillatorCanv {

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -107,7 +107,6 @@ private:
   void drawLineBetweenActivedScins(const HitPositions &pos);
   void drawMarkers(const HitPositions &pos);
   void drawDiagram(const DiagramDataMapVector &diagramData);
-  void reverseYAxis(TGraph *g);
   float changeSignalNumber(int signalNumber);
 
   void draw2dGeometry2();
@@ -148,14 +147,6 @@ private:
   std::vector< TMarker * > fUnRolledViewMarker;
   ColorTable layersColors[3]{kGray1, kGray2, kGray3};
 #endif
-
-  /*struct ScintillatorCanv
-  {
-    TBox *image;
-    TMarker *event;
-  } fScintCanv;
-  ScintillatorCanv fScintCanv2;
-  ScintillatorCanv **allScintilatorsCanv;*/
 };
 }
 #endif // GEOMETRYVISUALIZATOR_H_

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -31,6 +31,8 @@
 #include <memory>
 #include "./CommonTools.h"
 
+#include "DataProcessor.h"
+
 
 #include <TRootEmbeddedCanvas.h>
 
@@ -45,7 +47,19 @@ namespace jpet_event_display
     ~GeometryVisualizator();
     bool isGeoManagerInitialized() const;
     void loadGeometry(const std::string& geomFile);
+    void drawData();
     void drawOnlyGeometry();
+    
+    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas3d() { return fRootCanvas3d; }
+    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d() { return fRootCanvas2d; }
+    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvasDiagrams() { return fRootCanvasDiagrams; }
+
+  private: 
+
+
+#ifndef __CINT__
+
+
     void draw2dGeometry();
     void drawStrips(const std::map<int, std::vector<int> >& selection);
     void drawPads();
@@ -57,13 +71,7 @@ namespace jpet_event_display
     std::string getStripNodeName(int strip) const;
     void drawDiagram(const std::map<int, std::pair<float, float>> &diagramData);
 
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas3d() { return fRootCanvas3d; }
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d() { return fRootCanvas2d; }
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvasDiagrams() { return fRootCanvasDiagrams; }
-
-  private:
     enum ColorTable { kBlack = 1, kRed = 2, kBlue = 34, kGreen = 30 };
-    #ifndef __CINT__
     std::unique_ptr<TGeoManager> fGeoManager;
     int numberOfLayers = 0;
     int* numberOfScintilatorsInLayer; 
@@ -73,7 +81,8 @@ namespace jpet_event_display
     std::unique_ptr<TCanvas> fCanvas3d;
     std::unique_ptr<TCanvas> fCanvas2d;
     std::unique_ptr<TCanvas> fCanvasDiagrams;
-    #endif
+#endif
+
     struct ScintillatorCanv {
       TBox* image;
       TMarker* event;

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -100,10 +100,14 @@ private:
   void setAllStripsUnvisible2d();
   void setVisibility(const ScintillatorsInLayers &selection);
   void setVisibility2d(const ScintillatorsInLayers &selection);
+  void setMarker2d(const HitPositions &pos,
+                   const ScintillatorsInLayers &selection);
 
   void drawLineBetweenActivedScins(const HitPositions &pos);
   void drawMarkers(const HitPositions &pos);
   void drawDiagram(const DiagramDataMapVector &diagramData);
+  void reverseYAxis(TGraph *g);
+  double changeSignalNumber(int signalNumber);
 
   void draw2dGeometry2();
 

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -19,6 +19,8 @@
 #include "./CommonTools.h"
 #include <TAxis.h>
 #include <TBox.h>
+#include <TEllipse.h>
+#include <TGaxis.h>
 #include <TGeoManager.h>
 #include <TGeoNode.h>
 #include <TGeoTube.h>
@@ -27,14 +29,14 @@
 #include <TLine.h>
 #include <TMarker.h>
 #include <TMultiGraph.h>
+#include <TPoint.h>
+#include <TPolyLine.h>
+#include <TPolyMarker.h>
+#include <TPolyMarker3D.h>
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TView.h>
 #include <TVirtualPad.h>
-#include <TPoint.h>
-#include <TPolyMarker3D.h>
-#include <TEllipse.h>
-#include <TGaxis.h>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -42,82 +44,91 @@
 
 #include "DataProcessor.h"
 
-
 #include <TRootEmbeddedCanvas.h>
 
 class TCanvas;
 
 namespace jpet_event_display
 {
-  class GeometryVisualizator
+class GeometryVisualizator
+{
+public:
+  GeometryVisualizator(const int numberOfLayers, const int kLength,
+                       const std::vector<std::pair<int, double>> &layerStats);
+  ~GeometryVisualizator();
+
+  void showGeometry();
+  void drawData();
+
+  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas3d()
   {
-  public:
-    GeometryVisualizator(const int numberOfLayers, const int kLength,
-                         const std::vector<std::pair<int, double>> &layerStats);
-    ~GeometryVisualizator();
-    
-    void showGeometry();
-    void drawData();
+    return fRootCanvas3d;
+  }
+  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas2d()
+  {
+    return fRootCanvas2d;
+  }
+  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas2d2()
+  {
+    return fRootCanvas2d2;
+  }
+  inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvasDiagrams()
+  {
+    return fRootCanvasDiagrams;
+  }
 
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas3d() { return fRootCanvas3d; }
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d() { return fRootCanvas2d; }
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d2() { return fRootCanvas2d2; }
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvasDiagrams() { return fRootCanvasDiagrams; }
-
-  private: 
-
-
+private:
 #ifndef __CINT__
-    void createGeometry(const int numberOfLayers, const int kLength,
-                        const std::vector<std::pair<int, double>> &layerStats);
+  void createGeometry(const int numberOfLayers, const int kLength,
+                      const std::vector<std::pair<int, double>> &layerStats);
 
-    void updateCanvas(std::unique_ptr<TCanvas> &canvas);
+  void updateCanvas(std::unique_ptr<TCanvas> &canvas);
 
-    void draw2dGeometry();
-    void drawStrips(const ScintillatorsInLayers& selection);
-    void drawPads();
-    void setAllStripsUnvisible();
-    void setAllStripsUnvisible2d();
-    void setVisibility(const ScintillatorsInLayers& selection);
-    void setVisibility2d(const ScintillatorsInLayers& selection);
+  void draw2dGeometry();
+  void drawStrips(const ScintillatorsInLayers &selection);
+  void drawPads();
+  void setAllStripsUnvisible();
+  void setAllStripsUnvisible2d();
+  void setVisibility(const ScintillatorsInLayers &selection);
+  void setVisibility2d(const ScintillatorsInLayers &selection);
 
-    void drawLineBetweenActivedScins(const HitPositions &pos);
+  void drawLineBetweenActivedScins(const HitPositions &pos);
+  void drawMarkers(const HitPositions &pos);
+  void drawDiagram(const DiagramDataMapVector &diagramData);
 
-    void drawDiagram(const DiagramDataMapVector &diagramData);
+  void draw2dGeometry2();
 
-    void draw2dGeometry2();
+  enum ColorTable
+  {
+    kBlack = 1,
+    kRed = 2,
+    kBlue = 34,
+    kGreen = 30
+  };
+  std::unique_ptr<TGeoManager> fGeoManager;
+  int numberOfLayers = 0;
+  int *numberOfScintilatorsInLayer;
+  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas3d;
+  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d;
+  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d2;
+  std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasDiagrams;
+  std::unique_ptr<TCanvas> fCanvas3d;
+  std::unique_ptr<TCanvas> fCanvas2d;
+  std::unique_ptr<TCanvas> fCanvas2d2;
+  std::unique_ptr<TCanvas> fCanvasDiagrams;
 
-    enum ColorTable
-    {
-      kBlack = 1,
-      kRed = 2,
-      kBlue = 34,
-      kGreen = 30
-    };
-    std::unique_ptr<TGeoManager> fGeoManager;
-    int numberOfLayers = 0;
-    int* numberOfScintilatorsInLayer; 
-    std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas3d;
-    std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d;
-    std::unique_ptr<TRootEmbeddedCanvas> fRootCanvas2d2;
-    std::unique_ptr<TRootEmbeddedCanvas> fRootCanvasDiagrams;
-    std::unique_ptr<TCanvas> fCanvas3d;
-    std::unique_ptr<TCanvas> fCanvas2d;
-    std::unique_ptr<TCanvas> fCanvas2d2;
-    std::unique_ptr<TCanvas> fCanvasDiagrams;
+  int fScinLenghtWithoutScale = 0;
 
-    int fScinLenghtWithoutScale = 0;
-
-    int fLastDiagramVectorSize = 0;
+  int fLastDiagramVectorSize = 0;
 #endif
 
-    struct ScintillatorCanv {
-      TBox* image;
-      TMarker* event;
-    } fScintCanv;
-    ScintillatorCanv fScintCanv2;
-    ScintillatorCanv** allScintilatorsCanv;
-  };
-
+  struct ScintillatorCanv
+  {
+    TBox *image;
+    TMarker *event;
+  } fScintCanv;
+  ScintillatorCanv fScintCanv2;
+  ScintillatorCanv **allScintilatorsCanv;
+};
 }
-#endif  // GEOMETRYVISUALIZATOR_H_
+#endif // GEOMETRYVISUALIZATOR_H_

--- a/src/GeometryVisualizator.h
+++ b/src/GeometryVisualizator.h
@@ -16,20 +16,25 @@
 #ifndef GEOMETRYVISUALIZATOR_H_
 #define GEOMETRYVISUALIZATOR_H_
 
-#include <TView.h>
-#include <TVirtualPad.h>
+#include "./CommonTools.h"
+#include <TAxis.h>
+#include <TBox.h>
 #include <TGeoManager.h>
 #include <TGeoNode.h>
+#include <TGeoTube.h>
 #include <TGeoVolume.h>
-#include <TMarker.h>
-#include <TBox.h>
 #include <TGraph.h>
-#include <TAxis.h>
+#include <TLine.h>
+#include <TMarker.h>
+#include <TMultiGraph.h>
+#include <TROOT.h>
+#include <TSystem.h>
+#include <TView.h>
+#include <TVirtualPad.h>
 #include <cassert>
 #include <map>
-#include <vector>
 #include <memory>
-#include "./CommonTools.h"
+#include <vector>
 
 #include "DataProcessor.h"
 
@@ -43,14 +48,17 @@ namespace jpet_event_display
   class GeometryVisualizator
   {
   public:
-    GeometryVisualizator();
+    GeometryVisualizator(const int numberOfLayers,
+                         const std::vector<std::pair<int, double>> &layerStats);
     ~GeometryVisualizator();
-    bool isGeoManagerInitialized() const;
-    void loadGeometry(const std::string& geomFile);
-    void drawData();
-    void drawOnlyGeometry();
     
-    inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas3d() { return fRootCanvas3d; }
+    void showGeometry();
+    void drawData();
+
+    inline std::unique_ptr<TRootEmbeddedCanvas> &getCanvas3d()
+    {
+      return fRootCanvas3d;
+    }
     inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvas2d() { return fRootCanvas2d; }
     inline std::unique_ptr<TRootEmbeddedCanvas>& getCanvasDiagrams() { return fRootCanvasDiagrams; }
 
@@ -58,18 +66,19 @@ namespace jpet_event_display
 
 
 #ifndef __CINT__
+    void createGeometry(const int numberOfLayers,
+                        const std::vector<std::pair<int, double>>& layerStats);
 
+    void updateCanvas(std::unique_ptr<TCanvas> &canvas);
 
     void draw2dGeometry();
-    void drawStrips(const std::map<int, std::vector<int> >& selection);
+    void drawStrips(const ScintillatorsInLayers& selection);
     void drawPads();
     void setAllStripsUnvisible();
     void setAllStripsUnvisible2d();
-    void setVisibility(const std::map<int, std::vector<int> >& selection);
-    void setVisibility2d(const std::map<int, std::vector<int> >& selection);
-    std::string getLayerNodeName(int layer) const;
-    std::string getStripNodeName(int strip) const;
-    void drawDiagram(const std::map<int, std::pair<float, float>> &diagramData);
+    void setVisibility(const ScintillatorsInLayers& selection);
+    void setVisibility2d(const ScintillatorsInLayers& selection);
+    void drawDiagram(const DiagramDataMapVector& diagramData);
 
     enum ColorTable { kBlack = 1, kRed = 2, kBlue = 34, kGreen = 30 };
     std::unique_ptr<TGeoManager> fGeoManager;


### PR DESCRIPTION
Add support for JPetRawSignal, JPetEvent, change data structure to singleton, move creating geometry to GeometryVirtualizator, some refactoring of GeometryVirtualization, remove load geometry button(in final version geometry will be loaded from parambank, now geometry is hardcoded in eventdisplay), not working multiple diagrams( Divide on diagram canvas not creating pads )