### PR TITLE
Add ability to do not reset leading edge to 0

### DIFF
--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -328,13 +328,6 @@ bool DataProcessor::openFile(const char* filename)
   bool openFileResult = fReader.openFileAndLoadData(filename);
   dynamic_cast< JPetParamBank* >(fReader.getObjectFromFile(
                                    "ParamBank")); // just read param bank, no need to save it to variable
-  //long long numberOfTimeWindowses = fReader.getNbOfAllEntries();
-  //for (long long i = 0; i < numberOfTimeWindowses; i++) {
-  //  fReader.nthEntry(i);
-  //  fNumberOfEventsInFile +=
-  //    dynamic_cast<JPetTimeWindow&>(fReader.getCurrentEntry())
-  //    .getNumberOfEvents();
-  //}
   fNumberOfEventsInFile = std::numeric_limits<long long>::max();
   return openFileResult;
 }

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -148,6 +148,11 @@ public:
     return fNumberOfEventsInFile;
   }
 
+  void changeResetLeadingEdge()
+  {
+    fResetLeadingEdge = !fResetLeadingEdge;
+  }
+
 private:
 #ifndef __CINT__
   DataProcessor(const DataProcessor&) = delete;
@@ -177,6 +182,7 @@ private:
   unsigned int fNumberOfEventInCurrentTimeWindow = 0;
   JPetReader fReader;
   std::shared_ptr< JPetGeomMapping > fMapper;
+  bool fResetLeadingEdge = false;
 #endif
 };
 }

--- a/src/EventDisplay.cpp
+++ b/src/EventDisplay.cpp
@@ -19,23 +19,27 @@
 namespace jpet_event_display
 {
 
-const char *filetypes[] = {
-    "All files", "*", "ROOT files", "*.root", "Text files", "*.[tT][xX][tT]",
-    0,           0};
+const char* filetypes[] = {
+  "All files", "*", "ROOT files", "*.root", "Text files", "*.[tT][xX][tT]",
+  0,           0
+};
 
 EventDisplay::EventDisplay() {}
 
-EventDisplay::~EventDisplay() { fMainWindow->Cleanup(); }
+EventDisplay::~EventDisplay()
+{
+  fMainWindow->Cleanup();
+}
 
 void EventDisplay::run(
-    std::shared_ptr< JPetGeomMapping > mapper, const int numberOfLayers,
-    const int scintillatorLenght,
-    const std::vector< std::pair< int, double > > &layerStats)
+  std::shared_ptr< JPetGeomMapping > mapper, const int numberOfLayers,
+  const int scintillatorLenght,
+  const std::vector< std::pair< int, double > >& layerStats)
 {
 
   dataProcessor = std::unique_ptr< DataProcessor >(new DataProcessor(mapper));
   visualizator = std::unique_ptr< GeometryVisualizator >(
-      new GeometryVisualizator(numberOfLayers, scintillatorLenght, layerStats));
+                   new GeometryVisualizator(numberOfLayers, scintillatorLenght, layerStats));
   fGUIControls->eventNo = 0;
   fGUIControls->stepNo = 0;
   createGUI();
@@ -49,30 +53,30 @@ void EventDisplay::run(
 void EventDisplay::createGUI()
 {
   fMainWindow =
-      std::unique_ptr< TGMainFrame >(new TGMainFrame(gClient->GetRoot()));
+    std::unique_ptr< TGMainFrame >(new TGMainFrame(gClient->GetRoot()));
   fMainWindow->SetCleanup(kDeepCleanup);
   fMainWindow->Connect("CloseWindow()", "jpet_event_display::EventDisplay",
                        this, "CloseWindow()");
   const Int_t w_max = 1024;
   const Int_t h_max = 720;
   fMainWindow->SetWMSize(
-      w_max, h_max); // this is the only way to set the size of the main frame
+    w_max, h_max); // this is the only way to set the size of the main frame
   fMainWindow->SetLayoutBroken(kTRUE);
   assert(fMainWindow != 0);
   const Int_t w_GlobalFrame = w_max;
   const Int_t h_GlobalFrame = h_max;
   const Int_t w_Frame1 = 180;
   const Int_t h_Frame1 =
-      h_max -
-      12; // cause 2*5 margins from GlobalFrame and 2*1 margins from Frame1
+    h_max -
+    12; // cause 2*5 margins from GlobalFrame and 2*1 margins from Frame1
   const Int_t w_Frame2 = w_max - w_Frame1;
   const Int_t h_Frame2 = h_max - 12;
 
-  TGCompositeFrame *baseFrame = AddCompositeFrame(
-      fMainWindow.get(), w_GlobalFrame, h_GlobalFrame - 10, kVerticalFrame);
+  TGCompositeFrame* baseFrame = AddCompositeFrame(
+                                  fMainWindow.get(), w_GlobalFrame, h_GlobalFrame - 10, kVerticalFrame);
   fMainWindow->AddFrame(
-      baseFrame,
-      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+    baseFrame,
+    new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
   // saving background color in fFrameBackgroundColor
   gClient->GetColorByName("#e6e6e6", fFrameBackgroundColor);
@@ -80,13 +84,13 @@ void EventDisplay::createGUI()
 
   AddMenuBar(baseFrame);
 
-  TGCompositeFrame *globalFrame =
-      AddCompositeFrame(baseFrame, w_GlobalFrame, h_GlobalFrame - 10);
+  TGCompositeFrame* globalFrame =
+    AddCompositeFrame(baseFrame, w_GlobalFrame, h_GlobalFrame - 10);
 
-  TGGroupFrame *optionsFrame =
-      AddGroupFrame(globalFrame, "Options", w_Frame1, h_Frame1);
-  TGGroupFrame *displayFrame =
-      AddGroupFrame(globalFrame, "Display", w_Frame2, h_Frame2);
+  TGGroupFrame* optionsFrame =
+    AddGroupFrame(globalFrame, "Options", w_Frame1, h_Frame1);
+  TGGroupFrame* displayFrame =
+    AddGroupFrame(globalFrame, "Display", w_Frame2, h_Frame2);
 
   CreateOptionsFrame(optionsFrame);
   CreateDisplayFrame(displayFrame);
@@ -100,7 +104,7 @@ void EventDisplay::createGUI()
   fMainWindow->MapWindow();
 }
 
-void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
+void EventDisplay::CreateDisplayFrame(TGGroupFrame* parentFrame)
 {
   fDisplayTabView = std::unique_ptr< TGTab >(new TGTab(parentFrame, 1, 1));
   fDisplayTabView->ChangeBackground(fFrameBackgroundColor);
@@ -116,78 +120,87 @@ void EventDisplay::CreateDisplayFrame(TGGroupFrame *parentFrame)
 
   fDisplayTabView->SetEnabled(1, kTRUE);
   parentFrame->AddFrame(
-      fDisplayTabView.get(),
-      new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 5,
-                        1));
+    fDisplayTabView.get(),
+    new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 5,
+                      1));
 }
 
-void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
+void EventDisplay::CreateOptionsFrame(TGGroupFrame* parentFrame)
 {
-  TGCompositeFrame *frame1_1 =
-      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
-                        kLHintsExpandX | kLHintsTop, 1, 1, 1, 1);
+  TGCompositeFrame* frame1_1 =
+    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                      kLHintsExpandX | kLHintsTop, 1, 1, 1, 1);
 
-  TGCompositeFrame *frame1_1_2 =
-      AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame,
-                        kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
+  TGCompositeFrame* frame1_1_2 =
+    AddCompositeFrame(frame1_1, 1, 1, kHorizontalFrame,
+                      kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
 
   AddButton(frame1_1_2, "Read Data", "handleMenu(=1)");
 
-  TGCheckButton *markersCheck =
-      new TGCheckButton(frame1_1, "Save markers and lines between events", 1);
+  TGCheckButton* markersCheck =
+    new TGCheckButton(frame1_1, "Save markers and lines between events", 1);
   frame1_1->AddFrame(
-      markersCheck,
-      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
+    markersCheck,
+    new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
   markersCheck->ChangeBackground(fFrameBackgroundColor);
   markersCheck->Connect("Clicked()", "jpet_event_display::EventDisplay", this,
                         "checkBoxMarkersSignalFunction()");
 
-  TGCompositeFrame *frame1_2 =
-      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
-                        kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1);
+  TGCheckButton* leadingEdgeCheck =
+    new TGCheckButton(frame1_1, "Reset leading edge to 0", 1);
+  frame1_1->AddFrame(
+    leadingEdgeCheck,
+    new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
+  leadingEdgeCheck->ChangeBackground(fFrameBackgroundColor);
+  leadingEdgeCheck->Connect("Clicked()", "jpet_event_display::EventDisplay", this,
+                            "changeResetLeadingEdge()");
 
-  TGTab *pTab = new TGTab(frame1_2, 1, 1);
+  TGCompositeFrame* frame1_2 =
+    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                      kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1);
+
+  TGTab* pTab = new TGTab(frame1_2, 1, 1);
   pTab->ChangeBackground(fFrameBackgroundColor);
 
-  TGCompositeFrame *tf1 = pTab->AddTab("Info");
+  TGCompositeFrame* tf1 = pTab->AddTab("Info");
   tf1->ChangeBackground(fFrameBackgroundColor);
 
-  TGCompositeFrame *tabFrame1 = AddCompositeFrame(
-      tf1, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 5, 5, 5, 5);
+  TGCompositeFrame* tabFrame1 = AddCompositeFrame(
+                                  tf1, 1, 1, kVerticalFrame, kLHintsExpandX | kLHintsExpandY, 5, 5, 5, 5);
 
   fInputInfo = std::unique_ptr< TGLabel >(new TGLabel(
       tabFrame1, "No file read.", TGLabel::GetDefaultGC()(),
       TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor));
   fInputInfo->SetTextJustify(kTextTop | kTextLeft);
   tabFrame1->AddFrame(
-      fInputInfo.get(),
-      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1));
+    fInputInfo.get(),
+    new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 1, 1, 1, 1));
 
   pTab->SetEnabled(1, kTRUE);
   frame1_2->AddFrame(
-      pTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2,
-                              2, 5, 1));
+    pTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2,
+                            2, 5, 1));
 
-  TGCompositeFrame *frame1_3 =
-      AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
-                        kLHintsExpandX | kLHintsBottom, 2, 2, 2, 2);
+  TGCompositeFrame* frame1_3 =
+    AddCompositeFrame(parentFrame, 1, 1, kVerticalFrame,
+                      kLHintsExpandX | kLHintsBottom, 2, 2, 2, 2);
 
-  TGCompositeFrame *frame1_3_1 =
-      AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
-                        kLHintsExpandX | kLHintsTop, 2, 2, 2, 2);
+  TGCompositeFrame* frame1_3_1 =
+    AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
+                      kLHintsExpandX | kLHintsTop, 2, 2, 2, 2);
 
   AddButton(frame1_3_1, "&Next >", "doNext()");
   AddButton(frame1_3_1, "&Reset >", "doReset()");
   AddButton(frame1_3_1, "Show Data", "showData()");
   AddButton(frame1_3_1, "Start Virt", "startVirtualization()");
 
-  TGCompositeFrame *frame1_3_2 =
-      AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
-                        kLHintsExpandX | kLHintsTop, 5, 5, 5, 5);
+  TGCompositeFrame* frame1_3_2 =
+    AddCompositeFrame(frame1_3, 1, 1, kHorizontalFrame,
+                      kLHintsExpandX | kLHintsTop, 5, 5, 5, 5);
 
-  TGLabel *labelStep = new TGLabel(
-      frame1_3_2, "Step", TGLabel::GetDefaultGC()(),
-      TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
+  TGLabel* labelStep = new TGLabel(
+    frame1_3_2, "Step", TGLabel::GetDefaultGC()(),
+    TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
   labelStep->SetTextJustify(36);
   frame1_3_2->AddFrame(labelStep,
                        new TGLayoutHints(kLHintsLeft | kLHintsTop, 2, 2, 2, 2));
@@ -195,26 +208,26 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
   int fMaxEvents = 1000; // temporary
 
   fNumberEntryStep = std::unique_ptr< TGNumberEntry >(
-      new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
-                        TGNumberFormat::kNEAPositive,
-                        TGNumberFormat::kNELLimitMinMax, 1, fMaxEvents));
+                       new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
+                                         TGNumberFormat::kNEAPositive,
+                                         TGNumberFormat::kNELLimitMinMax, 1, fMaxEvents));
   frame1_3_2->AddFrame(fNumberEntryStep.get(),
                        new TGLayoutHints(kLHintsCenterX, 5, 5, 3, 4));
   fNumberEntryStep->Connect("ValueSet(Long_t)",
                             "jpet_event_display::EventDisplay", this,
                             "updateGUIControlls()");
 
-  TGLabel *labelEventNo = new TGLabel(
-      frame1_3_2, "Event no", TGLabel::GetDefaultGC()(),
-      TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
+  TGLabel* labelEventNo = new TGLabel(
+    frame1_3_2, "Event no", TGLabel::GetDefaultGC()(),
+    TGLabel::GetDefaultFontStruct(), kChildFrame, fFrameBackgroundColor);
   labelEventNo->SetTextJustify(36);
   frame1_3_2->AddFrame(labelEventNo,
                        new TGLayoutHints(kLHintsLeft | kLHintsTop, 2, 2, 2, 2));
 
   fNumberEntryEventNo = std::unique_ptr< TGNumberEntry >(
-      new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
-                        TGNumberFormat::kNEANonNegative,
-                        TGNumberFormat::kNELLimitMinMax, 0, fMaxEvents));
+                          new TGNumberEntry(frame1_3_2, 1, 5, -1, TGNumberFormat::kNESInteger,
+                              TGNumberFormat::kNEANonNegative,
+                              TGNumberFormat::kNELLimitMinMax, 0, fMaxEvents));
   frame1_3_2->AddFrame(fNumberEntryEventNo.get(),
                        new TGLayoutHints(kLHintsExpandX));
   fNumberEntryEventNo->Connect("ValueSet(Long_t)",
@@ -222,7 +235,7 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
                                "updateGUIControlls()");
 
   fProgBar = std::unique_ptr< TGHProgressBar >(
-      new TGHProgressBar(frame1_3, TGProgressBar::kFancy, 250));
+               new TGHProgressBar(frame1_3, TGProgressBar::kFancy, 250));
   fProgBar->SetBarColor("lightblue");
   fProgBar->ShowPosition(kTRUE, kFALSE, "%.0f events");
   fProgBar->SetRange(0, fMaxEvents);
@@ -230,70 +243,70 @@ void EventDisplay::CreateOptionsFrame(TGGroupFrame *parentFrame)
                      new TGLayoutHints(kLHintsCenterX, 5, 5, 3, 4));
 }
 
-void EventDisplay::AddTab(std::unique_ptr< TGTab > &pTabViews,
-                          std::unique_ptr< TRootEmbeddedCanvas > &saveCanvasPtr,
-                          const char *tabName, const char *canvasName)
+void EventDisplay::AddTab(std::unique_ptr< TGTab >& pTabViews,
+                          std::unique_ptr< TRootEmbeddedCanvas >& saveCanvasPtr,
+                          const char* tabName, const char* canvasName)
 {
-  TGCompositeFrame *tabView = pTabViews->AddTab(tabName);
+  TGCompositeFrame* tabView = pTabViews->AddTab(tabName);
   tabView->ChangeBackground(fFrameBackgroundColor);
   gStyle->SetCanvasPreferGL(kTRUE);
   saveCanvasPtr = std::unique_ptr< TRootEmbeddedCanvas >(
-      new TRootEmbeddedCanvas(canvasName, tabView, 600, 600));
+                    new TRootEmbeddedCanvas(canvasName, tabView, 600, 600));
   tabView->AddFrame(
-      saveCanvasPtr.get(),
-      new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 10, 10, 10, 1));
+    saveCanvasPtr.get(),
+    new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 10, 10, 10, 1));
 }
 
-void EventDisplay::AddButton(TGCompositeFrame *parentFrame,
-                             const char *buttonText, const char *signalFunction)
+void EventDisplay::AddButton(TGCompositeFrame* parentFrame,
+                             const char* buttonText, const char* signalFunction)
 {
-  TGTextButton *button = new TGTextButton(parentFrame, buttonText);
+  TGTextButton* button = new TGTextButton(parentFrame, buttonText);
   parentFrame->AddFrame(
-      button, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
+    button, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 5, 5, 3, 4));
   button->Connect("Clicked()", "jpet_event_display::EventDisplay", this,
                   signalFunction);
   button->SetTextJustify(36);
   button->ChangeBackground(fFrameBackgroundColor);
 }
 
-TGGroupFrame *EventDisplay::AddGroupFrame(TGCompositeFrame *parentFrame,
-                                          const char *frameName, Int_t width,
-                                          Int_t height)
+TGGroupFrame* EventDisplay::AddGroupFrame(TGCompositeFrame* parentFrame,
+    const char* frameName, Int_t width,
+    Int_t height)
 {
-  TGGroupFrame *frame = new TGGroupFrame(
-      parentFrame, frameName, kVerticalFrame, TGGroupFrame::GetDefaultGC()(),
-      TGGroupFrame::GetDefaultFontStruct(), fFrameBackgroundColor);
+  TGGroupFrame* frame = new TGGroupFrame(
+    parentFrame, frameName, kVerticalFrame, TGGroupFrame::GetDefaultGC()(),
+    TGGroupFrame::GetDefaultFontStruct(), fFrameBackgroundColor);
   frame->Resize(width, height);
   parentFrame->AddFrame(
-      frame, new TGLayoutHints(kLHintsLeft | kLHintsExpandY, 1, 1, 1, 1));
+    frame, new TGLayoutHints(kLHintsLeft | kLHintsExpandY, 1, 1, 1, 1));
   return frame;
 }
 
-TGCompositeFrame *EventDisplay::AddCompositeFrame(TGCompositeFrame *parentFrame,
-                                                  Int_t width, Int_t height,
-                                                  Int_t options, ULong_t hints,
-                                                  Int_t padleft, Int_t padright,
-                                                  Int_t padtop, Int_t padbottom)
+TGCompositeFrame* EventDisplay::AddCompositeFrame(TGCompositeFrame* parentFrame,
+    Int_t width, Int_t height,
+    Int_t options, ULong_t hints,
+    Int_t padleft, Int_t padright,
+    Int_t padtop, Int_t padbottom)
 {
-  TGCompositeFrame *frame =
-      new TGCompositeFrame(parentFrame, width, height, options);
+  TGCompositeFrame* frame =
+    new TGCompositeFrame(parentFrame, width, height, options);
   frame->ChangeBackground(fFrameBackgroundColor);
   parentFrame->AddFrame(
-      frame, new TGLayoutHints(hints, padleft, padright, padtop, padbottom));
+    frame, new TGLayoutHints(hints, padleft, padright, padtop, padbottom));
   return frame;
 }
 
-void EventDisplay::AddMenuBar(TGCompositeFrame *parentFrame)
+void EventDisplay::AddMenuBar(TGCompositeFrame* parentFrame)
 {
-  TGMenuBar *fMenuBar = new TGMenuBar(parentFrame, 1, 1, kHorizontalFrame);
+  TGMenuBar* fMenuBar = new TGMenuBar(parentFrame, 1, 1, kHorizontalFrame);
   fMenuBar->ChangeBackground(fFrameBackgroundColor);
 
-  TGLayoutHints *fMenuBarItemLayout =
-      new TGLayoutHints(kLHintsTop | kLHintsRight, 0, 0, 0, 0);
-  TGLayoutHints *fMenuBarLayout =
-      new TGLayoutHints(kLHintsLeft | kLHintsTop, 0, 0, 0, 0);
+  TGLayoutHints* fMenuBarItemLayout =
+    new TGLayoutHints(kLHintsTop | kLHintsRight, 0, 0, 0, 0);
+  TGLayoutHints* fMenuBarLayout =
+    new TGLayoutHints(kLHintsLeft | kLHintsTop, 0, 0, 0, 0);
 
-  TGPopupMenu *fMenuFile = new TGPopupMenu(gClient->GetRoot());
+  TGPopupMenu* fMenuFile = new TGPopupMenu(gClient->GetRoot());
   fMenuFile->AddEntry(" &Open Geometry...\tCtrl+O", E_OpenGeometry);
   fMenuFile->AddSeparator();
   fMenuFile->AddEntry(" &Open Data...\tCtrl+O", E_OpenData);
@@ -310,14 +323,15 @@ void EventDisplay::AddMenuBar(TGCompositeFrame *parentFrame)
   parentFrame->AddFrame(fMenuBar, fMenuBarLayout);
 }
 
-void EventDisplay::CloseWindow() { gApplication->Terminate(); }
+void EventDisplay::CloseWindow()
+{
+  gApplication->Terminate();
+}
 
 void EventDisplay::handleMenu(Int_t id)
 {
-  switch (id)
-  {
-  case E_OpenData:
-  {
+  switch (id) {
+  case E_OpenData: {
     TString dir("");
     fFileInfo->fFileTypes = filetypes;
     fFileInfo->fIniDir = StrDup(dir);
@@ -332,8 +346,7 @@ void EventDisplay::handleMenu(Int_t id)
     setMaxProgressBar(dataProcessor->getNumberOfEvents());
   }
   break;
-  case E_Close:
-  {
+  case E_Close: {
     CloseWindow();
   }
   break;
@@ -372,7 +385,10 @@ void EventDisplay::showData()
   fInputInfo->ChangeText(ProcessedData::getInstance().getInfo().c_str());
 }
 
-void EventDisplay::drawSelectedStrips() { visualizator->drawData(); }
+void EventDisplay::drawSelectedStrips()
+{
+  visualizator->drawData();
+}
 
 void EventDisplay::setMaxProgressBar(Int_t maxEvent)
 {
@@ -380,13 +396,15 @@ void EventDisplay::setMaxProgressBar(Int_t maxEvent)
   fProgBar->SetRange(0.0f, Float_t(maxEvent));
 }
 
-void EventDisplay::startVirtualization() { startVirtualizationLoop(10); }
+void EventDisplay::startVirtualization()
+{
+  startVirtualizationLoop(10);
+}
 
 void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
 {
   long long maxEvent = dataProcessor->getNumberOfEvents();
-  for (int i = 0; i < 100 && fGUIControls->eventNo < maxEvent; i++)
-  {
+  for (int i = 0; i < 100 && fGUIControls->eventNo < maxEvent; i++) {
     doNext();
     std::this_thread::sleep_for(std::chrono::milliseconds(waitTimeInMs));
   }
@@ -395,5 +413,10 @@ void EventDisplay::startVirtualizationLoop(const int waitTimeInMs)
 void EventDisplay::checkBoxMarkersSignalFunction()
 {
   visualizator->changeMarkersState();
+}
+
+void EventDisplay::changeResetLeadingEdge()
+{
+  dataProcessor->changeResetLeadingEdge();
 }
 }

--- a/src/EventDisplay.h
+++ b/src/EventDisplay.h
@@ -52,15 +52,13 @@
 namespace jpet_event_display
 {
 
-struct GUIControlls
-{
+struct GUIControlls {
   Int_t eventNo;
   Int_t stepNo;
   Int_t rootEntries;
 };
 
-enum EMessageTypes
-{
+enum EMessageTypes {
   M_FILE_OPEN,
   M_FILE_SAVE,
   M_FILE_EXIT
@@ -76,7 +74,7 @@ public:
 #ifndef __CINT__
   void run(std::shared_ptr< JPetGeomMapping > mapper, const int numberOfLayers,
            const int scintillatorLenght,
-           const std::vector< std::pair< int, double > > &layerStats);
+           const std::vector< std::pair< int, double > >& layerStats);
   void createGUI();
   void drawSelectedStrips();
   void setMaxProgressBar(Int_t maxEvent);
@@ -89,8 +87,7 @@ public:
     fProgBar->SetPosition(Float_t(num));
   }
 
-  enum HandleMenuAction
-  {
+  enum HandleMenuAction {
     E_OpenGeometry,
     E_OpenData,
     E_Close
@@ -106,33 +103,34 @@ public:
   void showData();
   void startVirtualization();
   void checkBoxMarkersSignalFunction();
+  void changeResetLeadingEdge();
 
-private:
+private :
 #ifndef __CINT__
-  EventDisplay(const EventDisplay &) = delete;
-  EventDisplay &operator=(const EventDisplay &) = delete;
+  EventDisplay(const EventDisplay&) = delete;
+  EventDisplay& operator=(const EventDisplay&) = delete;
 
-  void CreateDisplayFrame(TGGroupFrame *parentFrame);
-  void CreateOptionsFrame(TGGroupFrame *parentFrame);
+  void CreateDisplayFrame(TGGroupFrame* parentFrame);
+  void CreateOptionsFrame(TGGroupFrame* parentFrame);
 
-  void AddTab(std::unique_ptr< TGTab > &pTabViews,
-              std::unique_ptr< TRootEmbeddedCanvas > &saveCanvasPtr,
-              const char *tabName, const char *canvasName);
+  void AddTab(std::unique_ptr< TGTab >& pTabViews,
+              std::unique_ptr< TRootEmbeddedCanvas >& saveCanvasPtr,
+              const char* tabName, const char* canvasName);
 
-  void AddButton(TGCompositeFrame *parentFrame, const char *buttonText,
-                 const char *signalFunction);
+  void AddButton(TGCompositeFrame* parentFrame, const char* buttonText,
+                 const char* signalFunction);
 
-  TGGroupFrame *AddGroupFrame(TGCompositeFrame *parentFrame,
-                              const char *frameName, Int_t width, Int_t height);
+  TGGroupFrame* AddGroupFrame(TGCompositeFrame* parentFrame,
+                              const char* frameName, Int_t width, Int_t height);
 
-  TGCompositeFrame *
-  AddCompositeFrame(TGCompositeFrame *parentFrame, Int_t width, Int_t height,
+  TGCompositeFrame*
+  AddCompositeFrame(TGCompositeFrame* parentFrame, Int_t width, Int_t height,
                     Int_t options = kHorizontalFrame,
                     ULong_t hints = kLHintsExpandX | kLHintsExpandY,
                     Int_t padleft = 0, Int_t padright = 0, Int_t padtop = 0,
                     Int_t padbottom = 0);
 
-  void AddMenuBar(TGCompositeFrame *parentFrame);
+  void AddMenuBar(TGCompositeFrame* parentFrame);
 
   void startVirtualizationLoop(const int waitTimeInMs = 1000);
 
@@ -142,9 +140,9 @@ private:
   std::unique_ptr< GeometryVisualizator > visualizator;
 
   std::unique_ptr< TRint > fApplication =
-      std::unique_ptr< TRint >(new TRint("EventDisplay Gui", 0, 0));
+    std::unique_ptr< TRint >(new TRint("EventDisplay Gui", 0, 0));
   std::unique_ptr< GUIControlls > fGUIControls =
-      std::unique_ptr< GUIControlls >(new GUIControlls);
+    std::unique_ptr< GUIControlls >(new GUIControlls);
   std::unique_ptr< TGTab > fDisplayTabView;
   std::unique_ptr< TGMainFrame > fMainWindow;
   std::unique_ptr< TGNumberEntry > fNumberEntryStep;
@@ -153,7 +151,7 @@ private:
   std::unique_ptr< TGLabel > fInputInfo;
 
   std::unique_ptr< TGFileInfo > fFileInfo =
-      std::unique_ptr< TGFileInfo >(new TGFileInfo);
+    std::unique_ptr< TGFileInfo >(new TGFileInfo);
 #endif
 };
 }

--- a/src/GeometryVisualizator.cpp
+++ b/src/GeometryVisualizator.cpp
@@ -15,6 +15,7 @@
 
 #include "GeometryVisualizator.h"
 #include <JPetLoggerInclude.h>
+#include <limits>
 #include <TCanvas.h>
 #include <TFile.h>
 
@@ -470,12 +471,20 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector& diagramData)
     std::vector< float > trailingX;
     std::vector< float > trailingY;
     const float kPsToNs = 0.001;
+    float minXValue = std::numeric_limits<float>::max();
+    float maxXValue = - std::numeric_limits<float>::max(); // min() is returning min positive value
     for (auto it = diagramData[j].begin(); it != diagramData[j].end(); it++) {
       if (std::get< 3 >(*it) == JPetSigCh::Leading) {
-        leadingX.push_back(static_cast< float >(std::get< 2 >(*it)) * kPsToNs);
+        float x = static_cast<float>(std::get<2>(*it)) * kPsToNs;
+        if (x < minXValue)
+          minXValue = x;
+        leadingX.push_back(x);
         leadingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       } else {
-        trailingX.push_back(static_cast< float >(std::get< 2 >(*it)) * kPsToNs);
+        float x = static_cast<float>(std::get<2>(*it)) * kPsToNs;
+        if (x > maxXValue)
+          maxXValue = x;
+        trailingX.push_back(x);
         trailingY.push_back(changeSignalNumber(std::get< 0 >(*it)));
       }
     }
@@ -509,7 +518,7 @@ void GeometryVisualizator::drawDiagram(const DiagramDataMapVector& diagramData)
     mg->GetYaxis()->SetLabelOffset(999);
     mg->GetYaxis()->SetTickLength(0);
     mg->GetYaxis()->SetRangeUser(0, 5);
-    mg->GetXaxis()->SetLimits(0, 50);
+    mg->GetXaxis()->SetLimits(minXValue, maxXValue);
     mg->GetXaxis()->SetNdivisions(504, kFALSE);
     mg->GetXaxis()->SetTitle("Time (ns)");
     mg->GetYaxis()->SetTitle("Threshold Number");


### PR DESCRIPTION
Adds checkbox that allows to disable reseting leading edge to 0, also disable calculating number of events in file when opening new file(it reduced load time from ~6-7min to seconds for 3,4GB). When event can't be find in file, error is saved in log.